### PR TITLE
:green_heart: amended redis secret

### DIFF
--- a/helm_deploy/pre-sentence-service/values.yaml
+++ b/helm_deploy/pre-sentence-service/values.yaml
@@ -39,10 +39,8 @@ generic-service:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
       API_CLIENT_ID: "API_CLIENT_ID"
       API_CLIENT_SECRET: "API_CLIENT_SECRET"
-      SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
-      SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
       SESSION_SECRET: "SESSION_SECRET"
-    elasticache-redis:
+    pac-elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"
 


### PR DESCRIPTION
I've manually added `APPINSIGHTS_INSTRUMENTATIONKEY` and `SESSION_SECRET` to `pre-sentence-service` secret in the namespace and referenced the correct redis secret as it's called `pac-elasticache-redis`.
All pods in the namespace can have access to the same elasticache store, (probably shouldn't have been named pac-elasticache-redis but I didn't realise that at the time)