### PR TITLE
:green_heart: moved prometheus alerts

### DIFF
--- a/helm_deploy/pre-sentence-service/Chart.yaml
+++ b/helm_deploy/pre-sentence-service/Chart.yaml
@@ -7,6 +7,6 @@ dependencies:
   - name: generic-service
     version: 1.0.10
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
-  - name: generic-prometheus-alerts
-    version: 0.1.4
-    repository: https://ministryofjustice.github.io/hmpps-helm-charts
+#  - name: generic-prometheus-alerts
+#    version: 0.1.4
+#    repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/pre-sentence-service/values.yaml
+++ b/helm_deploy/pre-sentence-service/values.yaml
@@ -52,3 +52,6 @@ generic-service:
     cloudplatform-live1-2: "3.8.51.207/32"
     cloudplatform-live1-3: "35.177.252.54/32"
 
+#generic-prometheus-alerts:
+#  targetApplication: pre-sentence-service
+#  alertSeverity: prepare-a-case

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,6 +1,0 @@
----
-# Per environment values which override defaults in pre-sentence-service/values.yaml
-
-generic-prometheus-alerts:
-  targetApplication: pre-sentence-service
-  alertSeverity: prepare-a-case


### PR DESCRIPTION
Moved prometheus alerts back to values.yaml, following [readme](https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-prometheus-alerts) suggests it needs to be in there.
Commented out the alerts for now until we get the build deploying successfully so we don't spam the alerts channel.