### PR TITLE
Use Node.js 16.13.0 LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   integration-tests:
     docker:
-      - image: cimg/node:14.18.1-browsers
+      - image: cimg/node:16.13.0-browsers
       - image: circleci/postgres:10.13-ram
         environment:
           POSTGRES_PASSWORD: pre-sentence-service
@@ -30,7 +30,7 @@ parameters:
 
   node-version:
     type: string
-    default: 14.18.1-browsers
+    default: 16.13.0-browsers
 
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:14.18.1-buster-slim as base
+FROM node:16.13.0-buster-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To start the main services excluding the typescript app:
 
 `docker-compose up --remove-orphans hmpps-auth redis postgres gotenberg`
 
-Install dependencies using `npm install`, ensuring you are using >= `Node v14.18.1` LTS or >= `Node v16.11.1` Current
+Install dependencies using `npm install`, ensuring you are using >= `Node v16.13.0` (Gallium) LTS
 
 And then, to build the assets and start the app with nodemon:
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "clean": "rm -rf dist build node_modules stylesheets"
   },
   "engines": {
-    "node": ">=14.18.1 <15.0.0 || >=16.11.1 <17.0.0",
-    "npm": ">=6.4.1 <7.0.0 || >=7.22.0"
+    "node": ">=16.13.0 <17.0.0",
+    "npm": ">=8.0.0"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
👷 Updated CI to use Node.js 16.13.0 LTS
🔨 Updated to use Node.js 16.13.0 LTS
📝 Updated README

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>