### PR TITLE
PIC-1878 Create report in database

### DIFF
--- a/db/migrations/1641408084144-seed-data.ts
+++ b/db/migrations/1641408084144-seed-data.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class SeedData1641408084144 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        INSERT INTO report (id, "reportDefinitionId")
+        VALUES ('0a15ce57-c46e-4b71-84f0-49dbed4bb81e', 1),
+               ('0877ed35-e59a-4e94-b2bd-5d2283dd7dd7', 2);
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/integration_tests/integration/api/api.spec.ts
+++ b/integration_tests/integration/api/api.spec.ts
@@ -14,10 +14,11 @@ context('API v1', () => {
       cy.get('@request').then(response => {
         expect(response.status).to.eq(200)
         assert.isObject(response.body, 'Response is Object')
-        cy.wrap(response.body.raw[0]).should('include', {
+        cy.wrap(response.body).should('include', {
           status: 'NOT_STARTED',
+          reportDefinitionId: 1,
         })
-        reportId = response.body.raw[0].id
+        reportId = response.body.id
       })
     })
 
@@ -28,6 +29,7 @@ context('API v1', () => {
         assert.isObject(response.body, 'Response is Object')
         cy.wrap(response.body).should('include', {
           status: 'NOT_STARTED',
+          reportDefinitionId: 1,
         })
       })
     })
@@ -46,10 +48,11 @@ context('API v1', () => {
       cy.get('@request').then(response => {
         expect(response.status).to.eq(200)
         assert.isObject(response.body, 'Response is Object')
-        cy.wrap(response.body.raw[0]).should('include', {
+        cy.wrap(response.body).should('include', {
           status: 'NOT_STARTED',
+          reportDefinitionId: 2,
         })
-        reportId = response.body.raw[0].id
+        reportId = response.body.id
       })
     })
 
@@ -60,6 +63,7 @@ context('API v1', () => {
         assert.isObject(response.body, 'Response is Object')
         cy.wrap(response.body).should('include', {
           status: 'NOT_STARTED',
+          reportDefinitionId: 2,
         })
       })
     })

--- a/integration_tests/integration/api/api.spec.ts
+++ b/integration_tests/integration/api/api.spec.ts
@@ -32,7 +32,7 @@ context('API v1', () => {
       })
     })
 
-    it('should access to the created report in the UI', () => {
+    it('should allow access to the created report in the UI', () => {
       cy.visit(`/record-of-oral/${reportId}`).as('request')
       cy.get('h1').contains('Record of Oral Pre-Sentence Report')
     })
@@ -64,7 +64,7 @@ context('API v1', () => {
       })
     })
 
-    it('should access to the created report in the UI', () => {
+    it('should allow access to the created report in the UI', () => {
       cy.visit(`/short-format/${reportId}`).as('request')
       cy.get('h1').contains('Short Format Pre-Sentence Report')
     })

--- a/integration_tests/integration/api/api.spec.ts
+++ b/integration_tests/integration/api/api.spec.ts
@@ -1,0 +1,72 @@
+context('API v1', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+    cy.signIn()
+  })
+
+  describe('Record of Oral Pre-sentence Report', () => {
+    let reportId
+
+    it('creates a new report', () => {
+      cy.request('POST', '/api/v1/report/record-of-oral').as('request')
+      cy.get('@request').then(response => {
+        expect(response.status).to.eq(200)
+        assert.isObject(response.body, 'Response is Object')
+        cy.wrap(response.body.raw[0]).should('include', {
+          status: 'NOT_STARTED',
+        })
+        reportId = response.body.raw[0].id
+      })
+    })
+
+    it('returns the created report', () => {
+      cy.request('GET', `/api/v1/report/${reportId}`).as('request')
+      cy.get('@request').then(response => {
+        expect(response.status).to.eq(200)
+        assert.isObject(response.body, 'Response is Object')
+        cy.wrap(response.body).should('include', {
+          status: 'NOT_STARTED',
+        })
+      })
+    })
+
+    it('should access to the created report in the UI', () => {
+      cy.visit(`/record-of-oral/${reportId}`).as('request')
+      cy.get('h1').contains('Record of Oral Pre-Sentence Report')
+    })
+  })
+
+  describe('Short Format Pre-sentence Report', () => {
+    let reportId
+
+    it('creates a new report', () => {
+      cy.request('POST', '/api/v1/report/short-format').as('request')
+      cy.get('@request').then(response => {
+        expect(response.status).to.eq(200)
+        assert.isObject(response.body, 'Response is Object')
+        cy.wrap(response.body.raw[0]).should('include', {
+          status: 'NOT_STARTED',
+        })
+        reportId = response.body.raw[0].id
+      })
+    })
+
+    it('returns the created report', () => {
+      cy.request('GET', `/api/v1/report/${reportId}`).as('request')
+      cy.get('@request').then(response => {
+        expect(response.status).to.eq(200)
+        assert.isObject(response.body, 'Response is Object')
+        cy.wrap(response.body).should('include', {
+          status: 'NOT_STARTED',
+        })
+      })
+    })
+
+    it('should access to the created report in the UI', () => {
+      cy.visit(`/short-format/${reportId}`).as('request')
+      cy.get('h1').contains('Short Format Pre-Sentence Report')
+    })
+  })
+})

--- a/integration_tests/integration/record-of-oral/checkReport.spec.ts
+++ b/integration_tests/integration/record-of-oral/checkReport.spec.ts
@@ -4,7 +4,7 @@ import CheckReport from '../../record-of-oral/checkReport'
 import SignReport from '../../record-of-oral/signReport'
 
 context('Check report page', () => {
-  const path = `/${new BaseController().path}/123456789/check-report`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/check-report`
   let currentPage: CheckReport
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/courtDetails.spec.ts
+++ b/integration_tests/integration/record-of-oral/courtDetails.spec.ts
@@ -4,7 +4,7 @@ import CourtDetails from '../../record-of-oral/courtDetails'
 import OffenceDetails from '../../record-of-oral/offenceDetails'
 
 context('Sentencing court details report page', () => {
-  const path = `/${new BaseController().path}/123456789/court-details`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/court-details`
   let currentPage: CourtDetails
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/landing.spec.ts
+++ b/integration_tests/integration/record-of-oral/landing.spec.ts
@@ -4,7 +4,7 @@ import Page from '../../pages/page'
 import OffenderDetails from '../../record-of-oral/offenderDetails'
 
 context('Record of Oral Pre-Sentence Report landing page', () => {
-  const path = `/${new BaseController().path}/123456789`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e`
   let currentPage: LandingPage
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/offenceAnalysis.spec.ts
+++ b/integration_tests/integration/record-of-oral/offenceAnalysis.spec.ts
@@ -4,7 +4,7 @@ import OffenceAnalysis from '../../record-of-oral/offenceAnalysis'
 import OffenderAssessment from '../../record-of-oral/offenderAssessment'
 
 context('Offence analysis report page', () => {
-  const path = `/${new BaseController().path}/123456789/offence-analysis`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/offence-analysis`
   let currentPage: OffenceAnalysis
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/offenceDetails.spec.ts
+++ b/integration_tests/integration/record-of-oral/offenceDetails.spec.ts
@@ -4,7 +4,7 @@ import OffenceDetails from '../../record-of-oral/offenceDetails'
 import OffenceAnalysis from '../../record-of-oral/offenceAnalysis'
 
 context('Offence details report page', () => {
-  const path = `/${new BaseController().path}/123456789/offence-details`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/offence-details`
   let currentPage: OffenceDetails
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/offenderAssessment.spec.ts
+++ b/integration_tests/integration/record-of-oral/offenderAssessment.spec.ts
@@ -4,7 +4,7 @@ import OffenderAssessment from '../../record-of-oral/offenderAssessment'
 import RiskAssessment from '../../record-of-oral/riskAssessment'
 
 context('Offender assessment report page', () => {
-  const path = `/${new BaseController().path}/123456789/offender-assessment`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/offender-assessment`
   let currentPage: OffenderAssessment
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/offenderDetails.spec.ts
+++ b/integration_tests/integration/record-of-oral/offenderDetails.spec.ts
@@ -4,7 +4,7 @@ import OffenderDetails from '../../record-of-oral/offenderDetails'
 import CourtDetails from '../../record-of-oral/courtDetails'
 
 context('Offender details report page', () => {
-  const path = `/${new BaseController().path}/123456789/offender-details`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/offender-details`
   let currentPage: OffenderDetails
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/proposal.spec.ts
+++ b/integration_tests/integration/record-of-oral/proposal.spec.ts
@@ -4,7 +4,7 @@ import Proposal from '../../record-of-oral/proposal'
 import SourcesOfInformation from '../../record-of-oral/sourcesOfInformation'
 
 context('Proposal report page', () => {
-  const path = `/${new BaseController().path}/123456789/proposal`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/proposal`
   let currentPage: Proposal
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/reportCompleted.spec.ts
+++ b/integration_tests/integration/record-of-oral/reportCompleted.spec.ts
@@ -4,7 +4,7 @@ import SignReport from '../../record-of-oral/signReport'
 import ReportCompleted from '../../record-of-oral/reportCompleted'
 
 context('Report completed page', () => {
-  const path = `/${new BaseController().path}/123456789/sign-report`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/sign-report`
   let currentPage: SignReport | ReportCompleted
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/reportSaved.spec.ts
+++ b/integration_tests/integration/record-of-oral/reportSaved.spec.ts
@@ -3,7 +3,7 @@ import Page from '../../pages/page'
 import ReportSaved from '../../record-of-oral/reportSaved'
 
 context('Draft report saved page', () => {
-  const path = `/${new BaseController().path}/123456789/report-saved`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/report-saved`
   let currentPage: ReportSaved
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/riskAssessment.spec.ts
+++ b/integration_tests/integration/record-of-oral/riskAssessment.spec.ts
@@ -4,7 +4,7 @@ import RiskAssessment from '../../record-of-oral/riskAssessment'
 import Proposal from '../../record-of-oral/proposal'
 
 context('Risk assessment report page', () => {
-  const path = `/${new BaseController().path}/123456789/risk-assessment`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/risk-assessment`
   let currentPage: RiskAssessment
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/signReport.spec.ts
+++ b/integration_tests/integration/record-of-oral/signReport.spec.ts
@@ -4,7 +4,7 @@ import SignReport from '../../record-of-oral/signReport'
 import ReportCompleted from '../../record-of-oral/reportCompleted'
 
 context('Check report page', () => {
-  const path = `/${new BaseController().path}/123456789/sign-report`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/sign-report`
   let currentPage: SignReport
 
   beforeEach(() => {

--- a/integration_tests/integration/record-of-oral/sourcesOfInformation.spec.ts
+++ b/integration_tests/integration/record-of-oral/sourcesOfInformation.spec.ts
@@ -4,7 +4,7 @@ import SourcesOfInformation from '../../record-of-oral/sourcesOfInformation'
 import CheckReport from '../../record-of-oral/checkReport'
 
 context('Sources of information report page', () => {
-  const path = `/${new BaseController().path}/123456789/sources-of-information`
+  const path = `/${new BaseController().path}/0a15ce57-c46e-4b71-84f0-49dbed4bb81e/sources-of-information`
   let currentPage: SourcesOfInformation
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/checkReport.spec.ts
+++ b/integration_tests/integration/short-format/checkReport.spec.ts
@@ -4,7 +4,7 @@ import CheckReport from '../../short-format/checkReport'
 import SignReport from '../../short-format/signReport'
 
 context('Check report page', () => {
-  const path = `/${new BaseController().path}/123456789/check-report`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/check-report`
   let currentPage: CheckReport
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/courtDetails.spec.ts
+++ b/integration_tests/integration/short-format/courtDetails.spec.ts
@@ -4,7 +4,7 @@ import CourtDetails from '../../short-format/courtDetails'
 import OffenceDetails from '../../short-format/offenceDetails'
 
 context('Sentencing court details report page', () => {
-  const path = `/${new BaseController().path}/123456789/court-details`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/court-details`
   let currentPage: CourtDetails
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/landing.spec.ts
+++ b/integration_tests/integration/short-format/landing.spec.ts
@@ -4,7 +4,7 @@ import Page from '../../pages/page'
 import OffenderDetails from '../../short-format/offenderDetails'
 
 context('Record of Oral Pre-Sentence Report landing page', () => {
-  const path = `/${new BaseController().path}/123456789`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7`
   let currentPage: LandingPage
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/offenceAnalysis.spec.ts
+++ b/integration_tests/integration/short-format/offenceAnalysis.spec.ts
@@ -4,7 +4,7 @@ import OffenceAnalysis from '../../short-format/offenceAnalysis'
 import OffenderAssessment from '../../short-format/offenderAssessment'
 
 context('Offence analysis report page', () => {
-  const path = `/${new BaseController().path}/123456789/offence-analysis`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/offence-analysis`
   let currentPage: OffenceAnalysis
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/offenceDetails.spec.ts
+++ b/integration_tests/integration/short-format/offenceDetails.spec.ts
@@ -4,7 +4,7 @@ import OffenceDetails from '../../short-format/offenceDetails'
 import OffenceAnalysis from '../../short-format/offenceAnalysis'
 
 context('Offence details report page', () => {
-  const path = `/${new BaseController().path}/123456789/offence-details`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/offence-details`
   let currentPage: OffenceDetails
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/offenderAssessment.spec.ts
+++ b/integration_tests/integration/short-format/offenderAssessment.spec.ts
@@ -4,7 +4,7 @@ import OffenderAssessment from '../../short-format/offenderAssessment'
 import RiskAssessment from '../../short-format/riskAssessment'
 
 context('Offender assessment report page', () => {
-  const path = `/${new BaseController().path}/123456789/offender-assessment`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/offender-assessment`
   let currentPage: OffenderAssessment
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/offenderDetails.spec.ts
+++ b/integration_tests/integration/short-format/offenderDetails.spec.ts
@@ -4,7 +4,7 @@ import OffenderDetails from '../../short-format/offenderDetails'
 import CourtDetails from '../../short-format/courtDetails'
 
 context('Offender details report page', () => {
-  const path = `/${new BaseController().path}/123456789/offender-details`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/offender-details`
   let currentPage: OffenderDetails
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/proposal.spec.ts
+++ b/integration_tests/integration/short-format/proposal.spec.ts
@@ -4,7 +4,7 @@ import Proposal from '../../short-format/proposal'
 import SourcesOfInformation from '../../short-format/sourcesOfInformation'
 
 context('Proposal report page', () => {
-  const path = `/${new BaseController().path}/123456789/proposal`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/proposal`
   let currentPage: Proposal
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/reportCompleted.spec.ts
+++ b/integration_tests/integration/short-format/reportCompleted.spec.ts
@@ -4,7 +4,7 @@ import SignReport from '../../short-format/signReport'
 import ReportCompleted from '../../short-format/reportCompleted'
 
 context('Report completed page', () => {
-  const path = `/${new BaseController().path}/123456789/sign-report`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/sign-report`
   let currentPage: SignReport | ReportCompleted
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/reportSaved.spec.ts
+++ b/integration_tests/integration/short-format/reportSaved.spec.ts
@@ -3,7 +3,7 @@ import Page from '../../pages/page'
 import ReportSaved from '../../short-format/reportSaved'
 
 context('Draft report saved page', () => {
-  const path = `/${new BaseController().path}/123456789/report-saved`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/report-saved`
   let currentPage: ReportSaved
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/riskAssessment.spec.ts
+++ b/integration_tests/integration/short-format/riskAssessment.spec.ts
@@ -4,7 +4,7 @@ import RiskAssessment from '../../short-format/riskAssessment'
 import Proposal from '../../short-format/proposal'
 
 context('Risk assessment report page', () => {
-  const path = `/${new BaseController().path}/123456789/risk-assessment`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/risk-assessment`
   let currentPage: RiskAssessment
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/signReport.spec.ts
+++ b/integration_tests/integration/short-format/signReport.spec.ts
@@ -4,7 +4,7 @@ import SignReport from '../../short-format/signReport'
 import ReportCompleted from '../../short-format/reportCompleted'
 
 context('Check report page', () => {
-  const path = `/${new BaseController().path}/123456789/sign-report`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/sign-report`
   let currentPage: SignReport
 
   beforeEach(() => {

--- a/integration_tests/integration/short-format/sourcesOfInformation.spec.ts
+++ b/integration_tests/integration/short-format/sourcesOfInformation.spec.ts
@@ -4,7 +4,7 @@ import SourcesOfInformation from '../../short-format/sourcesOfInformation'
 import CheckReport from '../../short-format/checkReport'
 
 context('Sources of information report page', () => {
-  const path = `/${new BaseController().path}/123456789/sources-of-information`
+  const path = `/${new BaseController().path}/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7/sources-of-information`
   let currentPage: SourcesOfInformation
 
   beforeEach(() => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -21,7 +21,8 @@ import setUpAuthentication from './middleware/setUpAuthentication'
 import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
-import Report from './repositories/entities/report'
+
+import ReportService from './services/reportService'
 
 export default function createApplication(userService: UserService, databaseConnection: Connection): Application {
   const app = express()
@@ -40,9 +41,9 @@ export default function createApplication(userService: UserService, databaseConn
   app.use(pdfRenderer(new GotenbergClient(config.apis.gotenberg.apiUrl)))
   app.use(authorisationMiddleware())
 
-  const reportRepository = databaseConnection.getRepository(Report)
+  const reportService = new ReportService(databaseConnection)
 
-  app.use('/', indexRoutes(standardRouter(userService, reportRepository)))
+  app.use('/', indexRoutes(standardRouter(userService, reportService)))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler(process.env.NODE_ENV === 'production'))

--- a/server/controllers/record-of-oral/baseController.test.ts
+++ b/server/controllers/record-of-oral/baseController.test.ts
@@ -1,7 +1,15 @@
 import BaseController from './baseController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService')
 
 describe('Route Handlers - Base Controller', () => {
-  const handler = new BaseController()
+  let handler: BaseController
+
+  beforeAll(() => {
+    const mockedReportService = new ReportService()
+    handler = new BaseController(mockedReportService)
+  })
 
   describe('values', () => {
     it('should declare path as string', async () => {

--- a/server/controllers/record-of-oral/checkReportController.test.ts
+++ b/server/controllers/record-of-oral/checkReportController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import CheckReportController from './checkReportController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Check Report Controller', () => {
-  const handler = new CheckReportController()
+  let mockedReportService: ReportService
+  let handler: CheckReportController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new CheckReportController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/courtDetailsController.test.ts
+++ b/server/controllers/record-of-oral/courtDetailsController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import CourtDetailsController from './courtDetailsController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Court Details Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new CourtDetailsController()
+  let mockedReportService: ReportService
+  let handler: CourtDetailsController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new CourtDetailsController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/landingPageController.test.ts
+++ b/server/controllers/record-of-oral/landingPageController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import LandingPageController from './landingPageController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Record of Oral Pre-Sentence Report Landing Page Controller', () => {
-  const handler = new LandingPageController()
+  let mockedReportService: ReportService
+  let handler: LandingPageController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new LandingPageController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/offenceAnalysisController.test.ts
+++ b/server/controllers/record-of-oral/offenceAnalysisController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import OffenceAnalysisController from './offenceAnalysisController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Offence Analysis Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new OffenceAnalysisController()
+  let mockedReportService: ReportService
+  let handler: OffenceAnalysisController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new OffenceAnalysisController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/offenceDetailsController.test.ts
+++ b/server/controllers/record-of-oral/offenceDetailsController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import OffenceDetailsController from './offenceDetailsController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Offence Details Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new OffenceDetailsController()
+  let mockedReportService: ReportService
+  let handler: OffenceDetailsController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new OffenceDetailsController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/offenderAssessmentController.test.ts
+++ b/server/controllers/record-of-oral/offenderAssessmentController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import OffenderAssessmentController from './offenderAssessmentController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Offender Assessment Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new OffenderAssessmentController()
+  let mockedReportService: ReportService
+  let handler: OffenderAssessmentController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new OffenderAssessmentController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/offenderDetailsController.test.ts
+++ b/server/controllers/record-of-oral/offenderDetailsController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import OffenderDetailsController from './offenderDetailsController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Offender Details Controller', () => {
-  const handler = new OffenderDetailsController()
+  let mockedReportService: ReportService
+  let handler: OffenderDetailsController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new OffenderDetailsController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/proposalController.test.ts
+++ b/server/controllers/record-of-oral/proposalController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import ProposalController from './proposalController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Proposal Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new ProposalController()
+  let mockedReportService: ReportService
+  let handler: ProposalController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new ProposalController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/reportCompletedController.test.ts
+++ b/server/controllers/record-of-oral/reportCompletedController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import ReportCompletedController from './reportCompletedController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Report Completed Controller', () => {
-  const handler = new ReportCompletedController()
+  let mockedReportService: ReportService
+  let handler: ReportCompletedController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new ReportCompletedController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/reportSavedController.test.ts
+++ b/server/controllers/record-of-oral/reportSavedController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import ReportSavedController from './reportSavedController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Report Saved Controller', () => {
-  const handler = new ReportSavedController()
+  let mockedReportService: ReportService
+  let handler: ReportSavedController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new ReportSavedController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/riskAssessmentController.test.ts
+++ b/server/controllers/record-of-oral/riskAssessmentController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import RiskAssessmentController from './riskAssessmentController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Risk Assessment Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new RiskAssessmentController()
+  let mockedReportService: ReportService
+  let handler: RiskAssessmentController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new RiskAssessmentController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/signReportController.test.ts
+++ b/server/controllers/record-of-oral/signReportController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import SignReportController from './signReportController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Sign Report Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new SignReportController()
+  let mockedReportService: ReportService
+  let handler: SignReportController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new SignReportController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/record-of-oral/sourcesOfInformationController.test.ts
+++ b/server/controllers/record-of-oral/sourcesOfInformationController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import SourcesOfInformationController from './sourcesOfInformationController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Sources of Information Controller', () => {
-  const handler = new SourcesOfInformationController()
+  let mockedReportService: ReportService
+  let handler: SourcesOfInformationController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new SourcesOfInformationController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/shared/sharedController.test.ts
+++ b/server/controllers/shared/sharedController.test.ts
@@ -1,17 +1,42 @@
 import { Request, Response } from 'express'
 
 import SharedController from './sharedController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Shared Controller', () => {
-  const handler = new SharedController()
+  let mockedReportService: ReportService
+  let handler: SharedController
   let req: Request
   let res: Response
 
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new SharedController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
   beforeEach(() => {
     req = {
-      params: {},
+      params: {
+        reportId: '12345678',
+      },
       body: {},
-    } as Request
+    } as unknown as Request
     res = {
       render: jest.fn(),
       redirect: jest.fn(),
@@ -51,6 +76,7 @@ describe('Route Handlers - Shared Controller', () => {
       await handler.get(req, res)
       expect(res.render).toHaveBeenCalledWith(`${handler.path}/${handler.templatePath}`, {
         ...handler.templateValues,
+        reportId: '12345678',
         data: {
           ...handler.data,
         },

--- a/server/controllers/shared/sharedController.ts
+++ b/server/controllers/shared/sharedController.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
+import ReportService from '../../services/reportService'
+
 export interface TemplateValues {
   preSentenceType: string
   reportPath: string
@@ -19,6 +21,7 @@ export default class SharedController {
   data = {}
 
   templateValues: TemplateValues = {
+    reportId: '',
     reportPath: '',
     preSentenceType: '',
   }
@@ -27,18 +30,26 @@ export default class SharedController {
     required: [],
   }
 
+  constructor(private reportService: ReportService = null) {}
+
   protected renderTemplate(res: Response, templateValues: TemplateValues) {
     res.render(`${this.path}/${this.templatePath}`, templateValues)
   }
 
   get = async (req: Request, res: Response): Promise<void> => {
-    this.renderTemplate(res, {
-      reportId: req.params.reportId,
-      ...this.templateValues,
-      data: {
-        ...this.data,
-      },
-    })
+    const report = await this.reportService.getReportById(req.params.reportId)
+    if (report) {
+      this.renderTemplate(res, {
+        ...this.templateValues,
+        reportId: req.params.reportId,
+        data: {
+          ...this.data,
+          ...report,
+        },
+      })
+    } else {
+      res.redirect(`/${this.path}/${req.params.reportId}/not-found`)
+    }
   }
 
   post = async (req: Request, res: Response): Promise<void> => {

--- a/server/controllers/short-format/baseController.test.ts
+++ b/server/controllers/short-format/baseController.test.ts
@@ -1,7 +1,30 @@
 import BaseController from './baseController'
 
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
+
 describe('Route Handlers - Base Controller', () => {
-  const handler = new BaseController()
+  let handler: BaseController
+
+  beforeAll(() => {
+    const mockedReportService = new ReportService()
+    handler = new BaseController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   describe('values', () => {
     it('should declare path as string', async () => {

--- a/server/controllers/short-format/checkReportController.test.ts
+++ b/server/controllers/short-format/checkReportController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import CheckReportController from './checkReportController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Check Report Controller', () => {
-  const handler = new CheckReportController()
+  let mockedReportService: ReportService
+  let handler: CheckReportController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new CheckReportController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/courtDetailsController.test.ts
+++ b/server/controllers/short-format/courtDetailsController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import CourtDetailsController from './courtDetailsController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Court Details Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new CourtDetailsController()
+  let mockedReportService: ReportService
+  let handler: CourtDetailsController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new CourtDetailsController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/landingPageController.test.ts
+++ b/server/controllers/short-format/landingPageController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import LandingPageController from './landingPageController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Short Format Pre-Sentence Report Landing Page Controller', () => {
-  const handler = new LandingPageController()
+  let mockedReportService: ReportService
+  let handler: LandingPageController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new LandingPageController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/offenceAnalysisController.test.ts
+++ b/server/controllers/short-format/offenceAnalysisController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import OffenceAnalysisController from './offenceAnalysisController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Offence Analysis Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new OffenceAnalysisController()
+  let mockedReportService: ReportService
+  let handler: OffenceAnalysisController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new OffenceAnalysisController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/offenceDetailsController.test.ts
+++ b/server/controllers/short-format/offenceDetailsController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import OffenceDetailsController from './offenceDetailsController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Offence Details Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new OffenceDetailsController()
+  let mockedReportService: ReportService
+  let handler: OffenceDetailsController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new OffenceDetailsController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/offenderAssessmentController.test.ts
+++ b/server/controllers/short-format/offenderAssessmentController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import OffenderAssessmentController from './offenderAssessmentController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Offender Assessment Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new OffenderAssessmentController()
+  let mockedReportService: ReportService
+  let handler: OffenderAssessmentController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new OffenderAssessmentController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/offenderDetailsController.test.ts
+++ b/server/controllers/short-format/offenderDetailsController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import OffenderDetailsController from './offenderDetailsController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Offender Details Controller', () => {
-  const handler = new OffenderDetailsController()
+  let mockedReportService: ReportService
+  let handler: OffenderDetailsController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new OffenderDetailsController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/proposalController.test.ts
+++ b/server/controllers/short-format/proposalController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import ProposalController from './proposalController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Proposal Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new ProposalController()
+  let mockedReportService: ReportService
+  let handler: ProposalController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new ProposalController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/reportCompletedController.test.ts
+++ b/server/controllers/short-format/reportCompletedController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import ReportCompletedController from './reportCompletedController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Report Completed Controller', () => {
-  const handler = new ReportCompletedController()
+  let mockedReportService: ReportService
+  let handler: ReportCompletedController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new ReportCompletedController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/reportSavedController.test.ts
+++ b/server/controllers/short-format/reportSavedController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import ReportSavedController from './reportSavedController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Report Saved Controller', () => {
-  const handler = new ReportSavedController()
+  let mockedReportService: ReportService
+  let handler: ReportSavedController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new ReportSavedController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/riskAssessmentController.test.ts
+++ b/server/controllers/short-format/riskAssessmentController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import RiskAssessmentController from './riskAssessmentController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Risk Assessment Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new RiskAssessmentController()
+  let mockedReportService: ReportService
+  let handler: RiskAssessmentController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new RiskAssessmentController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/signReportController.test.ts
+++ b/server/controllers/short-format/signReportController.test.ts
@@ -2,6 +2,19 @@ import { Request, Response } from 'express'
 import { FormValidation, ValidatedForm, validateForm } from '../../utils/formValidation'
 
 import SignReportController from './signReportController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 jest.mock('../../utils/formValidation')
 
@@ -9,9 +22,19 @@ describe('Route Handlers - Sign Report Controller', () => {
   const validateFormMock = validateForm as jest.MockedFunction<
     (formData: FormData, formValidation: FormValidation) => ValidatedForm
   >
-  const handler = new SignReportController()
+  let mockedReportService: ReportService
+  let handler: SignReportController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new SignReportController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/controllers/short-format/sourcesOfInformationController.test.ts
+++ b/server/controllers/short-format/sourcesOfInformationController.test.ts
@@ -1,11 +1,34 @@
 import { Request, Response } from 'express'
 
 import SourcesOfInformationController from './sourcesOfInformationController'
+import ReportService from '../../services/reportService'
+
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
+})
 
 describe('Route Handlers - Sources of Information Controller', () => {
-  const handler = new SourcesOfInformationController()
+  let mockedReportService: ReportService
+  let handler: SourcesOfInformationController
   let req: Request
   let res: Response
+
+  beforeAll(() => {
+    mockedReportService = new ReportService()
+    handler = new SourcesOfInformationController(mockedReportService)
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
 
   beforeEach(() => {
     req = {

--- a/server/repositories/entities/fieldValue.ts
+++ b/server/repositories/entities/fieldValue.ts
@@ -16,6 +16,9 @@ export default class FieldValue {
   @Column()
   version: number
 
+  @Column()
+  reportId: string
+
   @ManyToOne(() => Field, entity => entity.id, { eager: true })
   field: Field
 

--- a/server/repositories/entities/report.ts
+++ b/server/repositories/entities/report.ts
@@ -10,6 +10,9 @@ export default class Report {
   @Column({ default: 'NOT_STARTED' })
   status: string
 
+  @Column()
+  reportDefinitionId: number
+
   @ManyToOne(() => ReportDefinition, entity => entity.id, { eager: true })
   reportDefinition: ReportDefinition
 

--- a/server/repositories/entities/reportDefinition.ts
+++ b/server/repositories/entities/reportDefinition.ts
@@ -1,6 +1,5 @@
 import { Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
 import Field from './field'
-import Report from './report'
 
 @Entity()
 export default class ReportDefinition {

--- a/server/repositories/entities/reportDefinition.ts
+++ b/server/repositories/entities/reportDefinition.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn } from 'typeorm'
 import Field from './field'
 
 @Entity()

--- a/server/repositories/entities/reportDefinition.ts
+++ b/server/repositories/entities/reportDefinition.ts
@@ -1,5 +1,6 @@
-import { Column, Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn } from 'typeorm'
+import { Column, Entity, JoinTable, ManyToMany, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
 import Field from './field'
+import Report from './report'
 
 @Entity()
 export default class ReportDefinition {

--- a/server/routes/record-of-oral/index.test.ts
+++ b/server/routes/record-of-oral/index.test.ts
@@ -2,17 +2,29 @@ import type { Express } from 'express'
 import request from 'supertest'
 import appWithAllRoutes from '../testutils/appSetup'
 
-let app: Express
-
-beforeEach(() => {
-  app = appWithAllRoutes({})
-})
-
-afterEach(() => {
-  jest.resetAllMocks()
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
 })
 
 describe('GET /record-of-oral', () => {
+  let app: Express
+
+  beforeAll(() => {
+    app = appWithAllRoutes({})
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
   it('should render index page', () => {
     return request(app)
       .get('/record-of-oral/123456789')

--- a/server/routes/record-of-oral/index.ts
+++ b/server/routes/record-of-oral/index.ts
@@ -17,7 +17,9 @@ import SignReportController from '../../controllers/record-of-oral/signReportCon
 import ReportSavedController from '../../controllers/record-of-oral/reportSavedController'
 import ReportCompletedController from '../../controllers/record-of-oral/reportCompletedController'
 
-export default function Index(): Router {
+import ReportService from '../../services/reportService'
+
+export default function Index(reportService: ReportService): Router {
   const router = Router()
   const routePrefix = (path: string) => `/${new BaseController().path}${path}`
 
@@ -28,21 +30,21 @@ export default function Index(): Router {
     post(path, handler.post)
   }
 
-  get('/:reportId', new LandingPageController().get)
+  get('/:reportId', new LandingPageController(reportService).get)
 
-  getAndPost('/:reportId/offender-details', new OffenderDetailsController())
-  getAndPost('/:reportId/court-details', new CourtDetailsController())
-  getAndPost('/:reportId/offence-details', new OffenceDetailsController())
-  getAndPost('/:reportId/offence-analysis', new OffenceAnalysisController())
-  getAndPost('/:reportId/offender-assessment', new OffenderAssessmentController())
-  getAndPost('/:reportId/risk-assessment', new RiskAssessmentController())
-  getAndPost('/:reportId/proposal', new ProposalController())
-  getAndPost('/:reportId/sources-of-information', new SourcesOfInformationController())
-  getAndPost('/:reportId/sign-report', new SignReportController())
+  getAndPost('/:reportId/offender-details', new OffenderDetailsController(reportService))
+  getAndPost('/:reportId/court-details', new CourtDetailsController(reportService))
+  getAndPost('/:reportId/offence-details', new OffenceDetailsController(reportService))
+  getAndPost('/:reportId/offence-analysis', new OffenceAnalysisController(reportService))
+  getAndPost('/:reportId/offender-assessment', new OffenderAssessmentController(reportService))
+  getAndPost('/:reportId/risk-assessment', new RiskAssessmentController(reportService))
+  getAndPost('/:reportId/proposal', new ProposalController(reportService))
+  getAndPost('/:reportId/sources-of-information', new SourcesOfInformationController(reportService))
+  getAndPost('/:reportId/sign-report', new SignReportController(reportService))
 
-  get('/:reportId/check-report', new CheckReportController().get)
-  get('/:reportId/report-saved', new ReportSavedController().get)
-  get('/:reportId/report-completed', new ReportCompletedController().get)
+  get('/:reportId/check-report', new CheckReportController(reportService).get)
+  get('/:reportId/report-saved', new ReportSavedController(reportService).get)
+  get('/:reportId/report-completed', new ReportCompletedController(reportService).get)
 
   return router
 }

--- a/server/routes/short-format/index.test.ts
+++ b/server/routes/short-format/index.test.ts
@@ -2,17 +2,29 @@ import type { Express } from 'express'
 import request from 'supertest'
 import appWithAllRoutes from '../testutils/appSetup'
 
-let app: Express
-
-beforeEach(() => {
-  app = appWithAllRoutes({})
-})
-
-afterEach(() => {
-  jest.resetAllMocks()
+jest.mock('../../services/reportService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getReportById: () => {
+        return new Promise(resolve => {
+          process.nextTick(() => resolve({}))
+        })
+      },
+    }
+  })
 })
 
 describe('GET /short-format', () => {
+  let app: Express
+
+  beforeAll(() => {
+    app = appWithAllRoutes({})
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
   it('should render index page', () => {
     return request(app)
       .get('/short-format/123456789')

--- a/server/routes/short-format/index.ts
+++ b/server/routes/short-format/index.ts
@@ -16,7 +16,9 @@ import CheckReportController from '../../controllers/short-format/checkReportCon
 import ReportSavedController from '../../controllers/short-format/reportSavedController'
 import ReportCompletedController from '../../controllers/short-format/reportCompletedController'
 
-export default function Index(): Router {
+import ReportService from '../../services/reportService'
+
+export default function Index(reportService: ReportService): Router {
   const router = Router()
   const routePrefix = (path: string) => `/${new BaseController().path}${path}`
   const get = (path: string, handler: RequestHandler) => router.get(routePrefix(path), asyncMiddleware(handler))
@@ -26,21 +28,21 @@ export default function Index(): Router {
     post(path, handler.post)
   }
 
-  get('/:reportId', new LandingPageController().get)
+  get('/:reportId', new LandingPageController(reportService).get)
 
-  getAndPost('/:reportId/offender-details', new OffenderDetailsController())
-  getAndPost('/:reportId/court-details', new CourtDetailsController())
-  getAndPost('/:reportId/offence-details', new OffenceDetailsController())
-  getAndPost('/:reportId/offence-analysis', new OffenceAnalysisController())
-  getAndPost('/:reportId/offender-assessment', new OffenderAssessmentController())
-  getAndPost('/:reportId/risk-assessment', new RiskAssessmentController())
-  getAndPost('/:reportId/proposal', new ProposalController())
-  getAndPost('/:reportId/sources-of-information', new SourcesOfInformationController())
-  getAndPost('/:reportId/sign-report', new SignReportController())
+  getAndPost('/:reportId/offender-details', new OffenderDetailsController(reportService))
+  getAndPost('/:reportId/court-details', new CourtDetailsController(reportService))
+  getAndPost('/:reportId/offence-details', new OffenceDetailsController(reportService))
+  getAndPost('/:reportId/offence-analysis', new OffenceAnalysisController(reportService))
+  getAndPost('/:reportId/offender-assessment', new OffenderAssessmentController(reportService))
+  getAndPost('/:reportId/risk-assessment', new RiskAssessmentController(reportService))
+  getAndPost('/:reportId/proposal', new ProposalController(reportService))
+  getAndPost('/:reportId/sources-of-information', new SourcesOfInformationController(reportService))
+  getAndPost('/:reportId/sign-report', new SignReportController(reportService))
 
-  get('/:reportId/check-report', new CheckReportController().get)
-  get('/:reportId/report-saved', new ReportSavedController().get)
-  get('/:reportId/report-completed', new ReportCompletedController().get)
+  get('/:reportId/check-report', new CheckReportController(reportService).get)
+  get('/:reportId/report-saved', new ReportSavedController(reportService).get)
+  get('/:reportId/report-completed', new ReportCompletedController(reportService).get)
 
   return router
 }

--- a/server/routes/standardRouter.ts
+++ b/server/routes/standardRouter.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express'
 import csurf from 'csurf'
-import { InsertResult } from 'typeorm'
 import auth from '../authentication/auth'
 import tokenVerifier from '../data/tokenVerification'
 import populateCurrentUser from '../middleware/populateCurrentUser'
@@ -10,7 +9,7 @@ import shortFormatRoutes from './short-format'
 import recordOfOralRoutes from './record-of-oral'
 import pdfRoutes from './pdf'
 
-import ReportService, { IReport } from '../services/reportService'
+import ReportService from '../services/reportService'
 
 const testMode = process.env.NODE_ENV === 'test'
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -4,14 +4,14 @@ import cookieSession from 'cookie-session'
 import createError from 'http-errors'
 import path from 'path'
 
-import { Repository } from 'typeorm'
 import allRoutes from '../index'
 import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'
 import standardRouter from '../standardRouter'
 import UserService from '../../services/userService'
 import * as auth from '../../authentication/auth'
-import Report from '../../repositories/entities/report'
+
+import ReportService from '../../services/reportService'
 
 const user = {
   name: 'john smith',
@@ -34,9 +34,9 @@ class MockUserService extends UserService {
   }
 }
 
-class MockRepository extends Repository<Report> {
+class MockReportService extends ReportService {
   constructor() {
-    super()
+    super(undefined)
   }
 }
 
@@ -65,5 +65,5 @@ function appSetup(route: Router, production: boolean): Express {
 
 export default function appWithAllRoutes({ production = false }: { production?: boolean }): Express {
   auth.default.authenticationMiddleware = () => (req, res, next) => next()
-  return appSetup(allRoutes(standardRouter(new MockUserService(), new MockRepository())), production)
+  return appSetup(allRoutes(standardRouter(new MockUserService(), new MockReportService())), production)
 }

--- a/server/services/reportService.ts
+++ b/server/services/reportService.ts
@@ -1,4 +1,4 @@
-import { Connection, getConnection, InsertResult } from 'typeorm'
+import { Connection } from 'typeorm'
 
 import Report from '../repositories/entities/report'
 import ReportDefinition from '../repositories/entities/reportDefinition'
@@ -11,8 +11,10 @@ export interface IReport {
 export default class ReportService {
   constructor(private databaseConnection: Connection = null) {}
 
-  public createReport(report: IReport): Promise<InsertResult> {
-    return getConnection().createQueryBuilder().insert().into(Report).values(report).execute()
+  public async createReport(report: IReport): Promise<Report> {
+    const reportRepository = this.databaseConnection.getRepository(Report)
+    const result = await reportRepository.create(report)
+    return reportRepository.save(result)
   }
 
   public getReportById(id: string): Promise<Report> {

--- a/server/services/reportService.ts
+++ b/server/services/reportService.ts
@@ -3,11 +3,16 @@ import { Connection, getConnection, InsertResult } from 'typeorm'
 import Report from '../repositories/entities/report'
 import ReportDefinition from '../repositories/entities/reportDefinition'
 
+export interface IReport {
+  id?: string
+  reportDefinitionId: number
+}
+
 export default class ReportService {
   constructor(private databaseConnection: Connection = null) {}
 
-  public createReport(reportDefinitionId: number): Promise<InsertResult> {
-    return getConnection().createQueryBuilder().insert().into(Report).values({ reportDefinitionId }).execute()
+  public createReport(report: IReport): Promise<InsertResult> {
+    return getConnection().createQueryBuilder().insert().into(Report).values(report).execute()
   }
 
   public getReportById(id: string): Promise<Report> {

--- a/server/services/reportService.ts
+++ b/server/services/reportService.ts
@@ -1,0 +1,41 @@
+import { Connection, getConnection, InsertResult } from 'typeorm'
+
+import Report from '../repositories/entities/report'
+import ReportDefinition from '../repositories/entities/reportDefinition'
+
+export default class ReportService {
+  constructor(private databaseConnection: Connection = null) {}
+
+  public createReport(reportDefinitionId: number): Promise<InsertResult> {
+    return getConnection().createQueryBuilder().insert().into(Report).values({ reportDefinitionId }).execute()
+  }
+
+  public getReportById(id: string): Promise<Report> {
+    return this.databaseConnection.getRepository(Report).findOne({
+      where: {
+        id,
+      },
+      relations: ['reportDefinition', 'reportDefinition.fields'],
+    })
+  }
+
+  public getAllReportsByType(type: string): Promise<Report[]> {
+    return this.databaseConnection.getRepository(Report).find({
+      where: {
+        reportDefinition: {
+          type,
+        },
+      },
+      relations: ['reportDefinition'],
+    })
+  }
+
+  public getDefinitionByType(type: string): Promise<ReportDefinition> {
+    return this.databaseConnection.getRepository(ReportDefinition).findOne({
+      select: ['id'],
+      where: {
+        type,
+      },
+    })
+  }
+}

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -6,8 +6,8 @@
 
   <main class="app-container govuk-body">
     <h1 class="govuk-heading-l">{{ applicationName }}</h1>
-    <p class="govuk-body"><a href="/record-of-oral/123456789" class="govuk-link govuk-link--no-visited-state">Record of Oral Pre-Sentence Report</a></p>
-    <p class="govuk-body"><a href="/short-format/987654321" class="govuk-link govuk-link--no-visited-state">Short Format Pre-Sentence Report</a></p>
+    <p class="govuk-body"><a href="/create/record-of-oral" class="govuk-link govuk-link--no-visited-state">Record of Oral Pre-Sentence Report</a></p>
+    <p class="govuk-body"><a href="/create/short-format" class="govuk-link govuk-link--no-visited-state">Short Format Pre-Sentence Report</a></p>
   </main>
 
 {% endblock %}

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -6,8 +6,8 @@
 
   <main class="app-container govuk-body">
     <h1 class="govuk-heading-l">{{ applicationName }}</h1>
-    <p class="govuk-body"><a href="/create/record-of-oral" class="govuk-link govuk-link--no-visited-state">Record of Oral Pre-Sentence Report</a></p>
-    <p class="govuk-body"><a href="/create/short-format" class="govuk-link govuk-link--no-visited-state">Short Format Pre-Sentence Report</a></p>
+    <p class="govuk-body"><a href="/record-of-oral/0a15ce57-c46e-4b71-84f0-49dbed4bb81e" class="govuk-link govuk-link--no-visited-state">Record of Oral Pre-Sentence Report</a></p>
+    <p class="govuk-body"><a href="/short-format/0877ed35-e59a-4e94-b2bd-5d2283dd7dd7" class="govuk-link govuk-link--no-visited-state">Short Format Pre-Sentence Report</a></p>
   </main>
 
 {% endblock %}


### PR DESCRIPTION
I've decided to seed data as part of the database migrations, I've done this as we'll want to be able to test each report in all environments and it will reduce the number of reports generated through testing.

We also always used test events for reports in NewTech so this gives us the same (but is better/easier).

Can review this later if we decide we don't want dummy reports in the database.

I've mocked ReportService in each of the unit tests as these will change over time as we start fetching and updating data in the next few stories.