### PR TITLE
Remove the primary button on the check report page.

### DIFF
--- a/integration_tests/integration/record-of-oral/checkReport.spec.ts
+++ b/integration_tests/integration/record-of-oral/checkReport.spec.ts
@@ -25,14 +25,5 @@ context('Oral - Check report page', () => {
     it('should include the task list', () => {
       cy.get('.moj-task-list').should('exist')
     })
-
-    it('should include the primary call to action button', () => {
-      currentPage.govukButton().contains('Sign your report').should('exist')
-    })
-
-    it('should move to correct screen upon valid form submission', () => {
-      currentPage.govukButton().contains('Sign your report').click()
-      Page.verifyOnPage(SignReport)
-    })
   })
 })

--- a/integration_tests/integration/short-format/checkReport.spec.ts
+++ b/integration_tests/integration/short-format/checkReport.spec.ts
@@ -25,14 +25,5 @@ context('Short Format - Check report page', () => {
     it('should include the task list', () => {
       cy.get('.moj-task-list').should('exist')
     })
-
-    it('should include the primary call to action button', () => {
-      currentPage.govukButton().contains('Sign your report').should('exist')
-    })
-
-    it('should move to correct screen upon valid form submission', () => {
-      currentPage.govukButton().contains('Sign your report').click()
-      Page.verifyOnPage(SignReport)
-    })
   })
 })

--- a/server/views/record-of-oral/check-report.njk
+++ b/server/views/record-of-oral/check-report.njk
@@ -292,8 +292,6 @@
         }
       ]
     }) }}
-
-    <a class="govuk-button govuk-!-margin-top-6" href="/record-of-oral/{{ reportId }}/sign-report">Sign your report</a>
   </main>
 
 {% endblock %}

--- a/server/views/short-format/check-report.njk
+++ b/server/views/short-format/check-report.njk
@@ -57,8 +57,6 @@
         }
       ]
     }) }}
-
-    <a class="govuk-button govuk-!-margin-top-6" href="/short-format/{{ reportId }}/sign-report">Sign your report</a>
   </main>
 
 {% endblock %}


### PR DESCRIPTION
🔥 Remove button from check report screen

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>