### PR TITLE
Remove IP restriction for Dev environment

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,14 +15,6 @@ generic-service:
     GOTENBERG_API_URL: "http://pre-sentence-service-gotenberg"
     PRE_SENTENCE_URL: "http://pre-sentence-service"
 
-  allowlist:
-    delius-dev-1: "35.178.19.203/32"
-    delius-dev-2: "35.177.67.41/32"
-    delius-dev-3: "35.178.40.151/32"
-    delius-test-1: "35.176.126.163/32"
-    delius-test-2: "35.178.162.73/32"
-    delius-test-3: "52.56.195.113/32"
-
 gotenberg:
   replicaCount: 1
 


### PR DESCRIPTION
Matt Ryall has asked to remove IP restrictions from our dev environment so that Unilink can test.

Mark Berridge and I have agreed that there's no issue in removing these restrictions for dev.

🚀 Remove IP restriction for Dev environment

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>