### PR TITLE
BUGFIX - Remove key details from error pages

### DIFF
--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -1,10 +1,10 @@
 {% extends "./partials/layout.njk" %}
 
+{% set pageTitle = applicationName + " - Authorisation Error" %}
+
+{% block beforeContent %}{% endblock %}
+
 {% block content %}
-  <h1 class="govuk-heading-l">
-    Authorisation Error
-  </h1>
-  <p>
-    You are not authorised to use this application.
-  </p>
+  <h1 class="govuk-heading-l">Authorisation Error</h1>
+  <p>You are not authorised to use this application.</p>
 {% endblock %}

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -2,6 +2,8 @@
 
 {% set pageTitle = applicationName + " - Error" %}
 
+{% block beforeContent %}{% endblock %}
+
 {% block content %}
 
   <main class="app-container">


### PR DESCRIPTION
🐛 Do not display key details banner on error pages

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>