### PR TITLE
PIC-2132 - BUGFIX incorrect API endpoint

### DIFF
--- a/server/controllers/api/apiController.ts
+++ b/server/controllers/api/apiController.ts
@@ -100,7 +100,8 @@ export default class ApiController {
     crn: string,
     eventId: string
   ): Promise<Array<IFieldValue>> {
-    const offenceInformation: OffenceInformation = await this.communityService.getOffenceInformation(crn, eventId)
+    const convictions: Array<OffenceInformation> = await this.communityService.getOffenceInformation(crn)
+    const offenceInformation = convictions.filter(conviction => conviction.index === eventId)[0]
     const mainOffences = offenceInformation.offences.filter((offence: Offence) => offence.mainOffence)
     const mainOffenceData: Array<string> = []
     mainOffences.forEach((offence: Offence) => {

--- a/server/services/communityService.ts
+++ b/server/services/communityService.ts
@@ -73,8 +73,8 @@ export default class CommunityService {
     return this.client({ path })
   }
 
-  async getOffenceInformation(crn: string, eventId: string) {
-    const path = `${this.apiUrl}/secure/offenders/crn/${crn}/convictions/${eventId}`
+  async getOffenceInformation(crn: string) {
+    const path = `${this.apiUrl}/secure/offenders/crn/${crn}/convictions`
     return this.client({ path })
   }
 }


### PR DESCRIPTION
Was incorrectly calling:
`secure​/offenders​/crn​/{crn}​/convictions/{eventId}`

Convictions endpoint does require `convictionId` and not the `eventId`

Should call:
`secure​/offenders​/crn​/{crn}​/convictions`

... and Find the event from `id`

**From Matt Ryal:**
CRN + Event Number should give the right sentence (which Community API calls Convictions helpfully)
This is the endpoint ​/secure​/offenders​/crn​/{crn}​/convictions
And the Event Number is in a field called index

🐛 Correct API call and apply filter by Event

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>