### PR TITLE
Node Security Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   integration-tests:
     docker:
-      - image: cimg/node:16.17.0-browsers
+      - image: cimg/node:16.17.1-browsers
       - image: localstack/localstack:0.14.2
         environment:
           SERVICES: sns
@@ -37,7 +37,7 @@ parameters:
 
   node-version:
     type: string
-    default: 16.17.0-browsers
+    default: 16.17.1-browsers
 
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:16.17.0-buster-slim as base
+FROM node:16.17.1-buster-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To start the main services excluding the typescript app:
 
 Now in a separate terminal window or tab, at the project root.
 
-Install dependencies using `npm install`, ensuring you are using >= `Node v16.15.1` (Gallium) LTS
+Install dependencies using `npm install`, ensuring you are using >= `Node v16.17.1` (Gallium) LTS
 
 And then, to build the assets and start the app with nodemon:
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean": "rm -rf dist build node_modules stylesheets test_results integration_tests/screenshots"
   },
   "engines": {
-    "node": ">=16.17.0 <17.0.0",
+    "node": ">=16.17.1 <17.0.0",
     "npm": ">=8.0.0"
   },
   "jest": {


### PR DESCRIPTION
⬆️ Change to use Node.js 16.17.1

See: https://nodejs.org/en/blog/vulnerability/september-2022-security-releases/

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>