### PR TITLE
Node LTS Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,25 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@3.11
-  slack: circleci/slack@4.4.2
+  hmpps: ministryofjustice/hmpps@6.1.0
+  slack: circleci/slack@4.10.1
 
 executors:
   integration-tests:
     docker:
-      - image: cimg/node:16.17.1-browsers
-      - image: localstack/localstack:0.14.2
+      - image: cimg/node:18.12.0-browsers
+      - image: localstack/localstack:1.2.0
         environment:
           SERVICES: sns
           DATA_DIR: /tmp/localstack/data
           TMP_DIR: /private
           DEFAULT_REGION: eu-west-2
-      - image: cimg/postgres:13.3
+      - image: cimg/postgres:13.8
         environment:
           POSTGRES_PASSWORD: pre-sentence-service
           POSTGRES_USER: pre-sentence-service
           POSTGRES_DB: pre-sentence-service
-      - image: bitnami/redis:5.0
+      - image: bitnami/redis:7.0.5
         environment:
           ALLOW_EMPTY_PASSWORD=yes
       - image: quay.io/hmpps/pre-sentence-service-wproofreader:latest
@@ -37,7 +37,7 @@ parameters:
 
   node-version:
     type: string
-    default: 16.17.1-browsers
+    default: 18.12.0-browsers
 
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ integration_tests/videos/
 integration_tests/screenshots/
 */*.iml
 **/Chart.lock
+/.localstack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:16.17.1-bullseye-slim as base
+FROM node:18.12.0-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available

--- a/README.md
+++ b/README.md
@@ -25,13 +25,17 @@ The app requires:
 
 ### Runing the app for development
 
+Ensure docker images are up-to-date
+
+`docker-compose pull`
+
 To start the main services excluding the typescript app: 
 
-`WP_LICENSE_KEY=<LICENSE_KEY> docker-compose up --scale app=0`
+`docker-compose up --scale app=0`
 
 Now in a separate terminal window or tab, at the project root.
 
-Install dependencies using `npm install`, ensuring you are using >= `Node v16.17.1` (Gallium) LTS or `Node v18.10.0` (Hydrogen)
+Install dependencies using `npm install`, ensuring you are using >= `Node v18.12.0` (Hydrogen) LTS
 
 And then, to build the assets and start the app with nodemon:
 
@@ -53,7 +57,7 @@ You can now access the service at `http://localhost:3000`
 
 For local running, start a test db, redis, and wiremock instance by:
 
-`WP_LICENSE_KEY=<LICENSE_KEY> docker-compose -f docker-compose-test.yml up`
+`docker-compose -f docker-compose-test.yml up`
 
 Then, in a separate terminal window or tab, at the project root; run the server in test mode by:
 

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
 
   redis:
-    image: 'bitnami/redis:5.0'
+    image: 'bitnami/redis:7.0.5'
     networks:
       - hmpps_int
     container_name: redis_int
@@ -32,7 +32,7 @@ services:
       - "9092:8080"
 
   gotenberg:
-    image: thecodingmachine/gotenberg:6.4.4
+    image: thecodingmachine/gotenberg:7.7.0
     networks:
       - hmpps_int
     container_name: gotenberg_int
@@ -43,7 +43,7 @@ services:
       test: [ 'CMD', 'curl', '-f', 'http://localhost:3000/ping' ]
 
   postgres:
-    image: postgres:13.3
+    image: postgres:13.8
     networks:
       - hmpps_int
     container_name: postgres_int
@@ -56,7 +56,7 @@ services:
       - POSTGRES_DB=pre-sentence-service
 
   localstack:
-    image: localstack/localstack:0.13.2
+    image: localstack/localstack:1.2.0
     networks:
       - hmpps_int
     container_name: localstack_int

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
 
   redis:
-    image: 'bitnami/redis:5.0'
+    image: 'bitnami/redis:7.0.5'
     networks:
       - hmpps
     container_name: redis
@@ -12,7 +12,7 @@ services:
       - "6379:6379"
 
   postgres:
-    image: postgres:13.3
+    image: postgres:13.8
     networks:
       - hmpps
     container_name: postgres
@@ -49,7 +49,7 @@ services:
       - "9092:8080"
 
   gotenberg:
-    image: thecodingmachine/gotenberg:6.4.4
+    image: thecodingmachine/gotenberg:7.7.0
     networks:
       - hmpps
     container_name: gotenberg
@@ -60,7 +60,7 @@ services:
       test: [ 'CMD', 'curl', '-f', 'http://localhost:3000/ping' ]
 
   localstack:
-    image: localstack/localstack:0.13.2
+    image: localstack/localstack:1.2.0
     networks:
       - hmpps
     container_name: localstack

--- a/helm_deploy/pre-sentence-service/values.yaml
+++ b/helm_deploy/pre-sentence-service/values.yaml
@@ -66,7 +66,7 @@ gotenberg:
 
   image:
     repository: thecodingmachine/gotenberg
-    tag: 6.4.4
+    tag: 7.7.0
     port: 3000
 
   ingress:

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "clean": "rm -rf dist build node_modules stylesheets test_results integration_tests/screenshots"
   },
   "engines": {
-    "node": ">=16.17.1 <17.0.0 || >=18.10.0 <19.0.0",
-    "npm": ">=8.0.0"
+    "node": ">=18.12.0 <19.0.0",
+    "npm": ">=8.19.2"
   },
   "jest": {
     "preset": "ts-jest",

--- a/server/data/gotenbergClient.test.ts
+++ b/server/data/gotenbergClient.test.ts
@@ -19,8 +19,8 @@ describe('Gotenberg client tests', () => {
   const htmlString = '<html><head><title>A title</title></head><body><p>A document</p></body>'
 
   describe('Render HTML as PDF', () => {
-    it('POST /convert/html', async () => {
-      fakeApi.post('/convert/html').reply(200, pdfStream)
+    it('POST /forms/chromium/convert/html', async () => {
+      fakeApi.post('/forms/chromium/convert/html').reply(200, pdfStream)
       const data = await client.renderPdfFromHtml(htmlString)
       expect(data).toEqual(Buffer.from(pdfStream))
       expect(nock.isDone()).toBe(true)

--- a/server/data/gotenbergClient.ts
+++ b/server/data/gotenbergClient.ts
@@ -21,7 +21,7 @@ export default class GotenbergClient {
     const { headerHtml, footerHtml, marginBottom, marginLeft, marginRight, marginTop } = options
     try {
       const request = superagent
-        .post(`${this.gotenbergHost}/convert/html`)
+        .post(`${this.gotenbergHost}/forms/chromium/convert/html`)
         .set('Content-Type', 'multi-part/form-data')
         .buffer(true)
         .attach('files', Buffer.from(html), 'index.html')
@@ -31,7 +31,9 @@ export default class GotenbergClient {
       if (headerHtml) request.attach('files', Buffer.from(headerHtml), 'header.html')
       if (footerHtml) request.attach('files', Buffer.from(footerHtml), 'footer.html')
 
-      // Gotenberg defaults to using A4 format. Page size and margins specified in inches
+      // Set paper size to A4. Page size and margins specified in inches
+      request.field('paperWidth', 8.27)
+      request.field('paperHeight', 11.7)
       if (marginTop) request.field('marginTop', marginTop)
       if (marginBottom) request.field('marginBottom', marginBottom)
       if (marginLeft) request.field('marginLeft', marginLeft)
@@ -41,7 +43,7 @@ export default class GotenbergClient {
       const response = await request
       return response.body
     } catch (err) {
-      logger.error(`Error POST to gotenberg:/convert/html - {}`, err)
+      logger.error(`Error POST to gotenberg:/forms/chromium/convert/html - {}`, err)
       return undefined
     }
   }


### PR DESCRIPTION
## What does this pull request do?
Update to use and require Node v18.12.0 (Hydrogen) LTS
Update Orbs
Update gotenbergClient to support v7.x
Update README accordingly

## What is the intent behind these changes?
Ensure the service uses the LTS version of Node.js - see https://github.com/nodejs/release#release-schedule
Update dependencies and additional services to the latest versions