### PR TITLE
WProofreader Ingress Controller

### DIFF
--- a/helm_deploy/pre-sentence-service/values.yaml
+++ b/helm_deploy/pre-sentence-service/values.yaml
@@ -11,6 +11,7 @@ generic-service:
 
   ingress:
     v1_2_enabled: true
+    v0_47_enabled: false
     enabled: true
     host: app-hostname.local    # override per environment
     tlsSecretName: pre-sentence-service-cert
@@ -109,7 +110,9 @@ wproofreader:
     port: 8081
 
   ingress:
-    enabled: false
+    v1_2_enabled: true
+    v0_47_enabled: false
+    enabled: true
 
   resources:
     requests:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -28,6 +28,4 @@ gotenberg:
 wproofreader:
 
   ingress:
-    v1_2_enabled: true
-    enabled: true
     host: pre-sentence-service-wproofreader-dev.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -37,8 +37,6 @@ gotenberg:
 wproofreader:
 
   ingress:
-    v1_2_enabled: true
-    enabled: true
     host: pre-sentence-service-wproofreader-preprod.hmpps.service.justice.gov.uk
 
     allowList:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -33,8 +33,6 @@ generic-service:
 wproofreader:
 
   ingress:
-    v1_2_enabled: true
-    enabled: true
     host: pre-sentence-service-wproofreader.hmpps.service.justice.gov.uk
 
   allowList:


### PR DESCRIPTION
## What does this pull request do?
🔧 Disable ingress controller v0.47
♻️ Refactor values

## What is the intent behind these changes?
Cloud Platform will be carrying out the Kubernetes 1.22 upgrade from Tuesday 15th November.
Before this time, we must switch to Ingress controller v1.2 and disable v0.47.

See: https://github.com/ministryofjustice/hmpps-helm-charts/releases/tag/generic-service-1.5.0

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>