### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@6.1.0
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.10.1
 
 executors:
@@ -20,11 +20,9 @@ executors:
           POSTGRES_USER: pre-sentence-service
           POSTGRES_DB: pre-sentence-service
       - image: bitnami/redis:7.0.5
-        environment:
-          ALLOW_EMPTY_PASSWORD=yes
+        environment: ALLOW_EMPTY_PASSWORD=yes
       - image: quay.io/hmpps/pre-sentence-service-wproofreader:latest
     working_directory: ~/app
-
 
 parameters:
   alerts-slack-channel:
@@ -38,7 +36,6 @@ parameters:
   node-version:
     type: string
     default: 20.5.1-browsers
-
 
 jobs:
   build:
@@ -67,7 +64,8 @@ jobs:
             export BUILD_NUMBER=${DATE}.${CIRCLE_BUILD_NUM}
             export GIT_REF="$CIRCLE_SHA1"
             npm run record-build-info
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
       - persist_to_workspace:

--- a/helm_deploy/pre-sentence-service/Chart.yaml
+++ b/helm_deploy/pre-sentence-service/Chart.yaml
@@ -5,13 +5,13 @@ name: pre-sentence-service
 version: 1.0.0
 dependencies:
   - name: generic-service
-    version: 2.7.4
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
     alias: gotenberg
-    version: 2.7.4
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
     alias: wproofreader
-    version: 2.7.4
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

0 allowlist(s) have been detected that can be migrated.


