### PR TITLE
add shading on do/dont lists

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -13,5 +13,5 @@
 .designer-row
   background-color: #f3f2f1
 
-.nhsuk-do-dont-list
+.background-grey
   background-color: #F0F4F5

--- a/server/views/psr/psr-start.njk
+++ b/server/views/psr/psr-start.njk
@@ -41,7 +41,8 @@
         {
           item: "adhere to child safeguarding and domestic abuse policy expectations"
         }
-      ]
+      ],
+      classes: "background-grey"
     }) }}
 
     {{ list({
@@ -60,7 +61,8 @@
         {
           item: "disregard any diversity and inclusion issues that may present "
         }
-      ]
+      ],
+      classes: "background-grey"
     }) }}
 
     <h1 class="govuk-heading-l">Before you finish a PSR</h1>


### PR DESCRIPTION
Shading added:

<img width="1194" height="585" alt="image" src="https://github.com/user-attachments/assets/5e55aa16-6327-409f-a7e2-4b71927662b5" />
