### PR TITLE
Add the Option to Skip Auth in Local Set Ups

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -122,5 +122,6 @@ export default {
   },
   dev: {
     fakeAdditionalOffences: get('DEV_FAKE_ADDITIONAL_OFFENCES', 'false') === 'true',
+    skipAuth: get('SKIP_AUTH', 'false') === 'true',
   },
 }

--- a/server/routes/standardRouter.ts
+++ b/server/routes/standardRouter.ts
@@ -36,7 +36,7 @@ export default function standardRouter(userService: UserService): Router {
   const eventService = new EventService()
   logger.info('StandardRouter: EventService instance created, passing to PSR routes')
 
-  if (!testMode) {
+  if (!testMode && !config.dev.skipAuth) {
     router.use(setUpAuthentication())
     router.use(authorisationMiddleware())
     router.use(auth.authenticationMiddleware(tokenVerifier))


### PR DESCRIPTION
### Justification: Remove any friction with local development.

**Why:** The hmpps-auth dev user (AUTH_USER) has `authSource: nomis` (prison system), but the app now requires `authSource: delius `(probation system), so the local test user will always redirect to /authError. This may have always been the case considering the test user cant trigger the delius integration layer anyway.

**Solution:** Add opt-in `SKIP_AUTH` flag for local development only. Eliminates friction during local development and allows for quicker iteration within the app, without requiring you to manage dev env secrets.

Open to implementing a cleaner approach if anybody wants to suggest one.