### PR TITLE
Prs 113 brancing deployment add a dev branch

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -47,7 +47,7 @@ jobs:
       environment: ${{ matrix.environments }}
   build:
     name: Build docker image from hmpps-github-actions
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
     needs:
       - node_integration_tests
@@ -60,7 +60,8 @@ jobs:
       docker_multiplatform: false
   deploy_dev:
     name: Deploy to the dev environment
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    # Only deploy to dev from the develop branch, not main.
+    if: github.ref == 'refs/heads/develop'
     needs:
     - build
     - helm_lint
@@ -71,10 +72,11 @@ jobs:
       app_version: '${{ needs.build.outputs.app_version }}'
   deploy_preprod:
     name: Deploy to the preprod environment
+    # Only deploy to preprod from main; merge develop to main when you want to deploy.
+    if: github.ref == 'refs/heads/main'
     needs:
     - build
     - helm_lint
-    - deploy_dev
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
     with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,7 +60,7 @@ jobs:
       docker_multiplatform: false
   deploy_dev:
     name: Deploy to the dev environment
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     needs:
     - build
     - helm_lint

--- a/README.md
+++ b/README.md
@@ -88,3 +88,28 @@ API documentation is provided via Swagger.
 Once the applicaiton is running you can access the Swagger UI at:
 
 `http://localhost:3000/api/docs`
+
+---
+
+## Branching & Deployments
+### Branching
+We use the following branching strategy:
+- `main` - protected branch, deployable to preprod and prod environments
+- `develop` - protected branch, deployable to dev environment on merge
+- Feature branches - created from `develop`, merged back to `develop` when ready
+
+We use a Gitflow process, with pull requests from feature branches
+to `develop`, and from `develop` to `main`.
+
+### Deployments
+
+| Env     | Branch  | Trigger   | Approval | Examples                                    |
+|---------|---------|-----------|----------|---------------------------------------------|
+| dev     | develop | Automatic | None     | When PR is merged to develop branch         |
+| preprod | main    | Automatic | None     | When PR is merged to main                   |
+| prod    | main    | Automatic | Manual   | When deployment is manually approved in GHA |
+
+**Additional protections:**
+1. Commits must be signed
+2. Only developers with write access can merge PRs to `develop` and `main` branches.
+3. Only developers with write access can approve deployments to prod.


### PR DESCRIPTION
Summary: Allow develop branch to deploy to dev environment.

Key changes:
* Updated GHA deployment workflow to allow develop branch to deploy to dev environment.
* Updated readme with branching and deployment details