### PR TITLE
PRS-125: Wrong date on completion page

### DIFF
--- a/server/views/psr/publish-report.njk
+++ b/server/views/psr/publish-report.njk
@@ -14,7 +14,7 @@
         <section class="psr-complete-card">
           <h1 class="govuk-heading-m psr-complete-card__title">
             Pre-sentence report completed
-            <span class="psr-complete-card__date">{{ data.createdAt | formatDate }}</span>
+            <span class="psr-complete-card__date">{{ data.submittedAt | formatDate }}</span>
           </h1>
           <p class="govuk-heading-m psr-complete-card__title govuk-!-margin-bottom-0 govuk-!-font-weight-regular">{{ data.name }}</p>
           <p class="govuk-heading-m psr-complete-card__title govuk-!-font-weight-bold govuk-!-margin-bottom-5 govuk-!-padding-top-0">CRN: {{ data.crn }}</p>


### PR DESCRIPTION
Replace `createdAt` with `submittedAt` variable in publish-report.njk