### PR TITLE
Autosave fixes

### DIFF
--- a/assets/js/ckeditor5setup.js
+++ b/assets/js/ckeditor5setup.js
@@ -172,10 +172,6 @@ document.addEventListener('DOMContentLoaded', () => {
         return true
       }
 
-      if (currentPath.indexOf('/sign-your-report') > 0) {
-        return true
-      }
-
       const formElement = document.querySelector('form[data-autosave="true"]')
 
       if (!formElement) {
@@ -183,10 +179,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       event.preventDefault()
-      const form = $(formElement)
       const redirectPath = targetLink.getAttribute('href')
       const targetSegment = redirectPath.substr(redirectPath.lastIndexOf('/') + 1)
 
+      const form = $(formElement)
       form.attr('action', currentPath + '?redirectPath=' + targetSegment)
       form.submit()
     })

--- a/assets/js/confirm-modal.js
+++ b/assets/js/confirm-modal.js
@@ -58,6 +58,11 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   form.addEventListener('submit', function (e) {
+    // Only intercept button-triggered submits, not programmatic saves (e.g. side-nav)
+    if (!e.submitter) {
+      return
+    }
+    
     if (allowSubmit) {
       return
     }

--- a/assets/js/save-on-exit.js
+++ b/assets/js/save-on-exit.js
@@ -265,7 +265,7 @@
     window.addEventListener('beforeunload', onBeforeUnload)
   }
 
-  function addListenersToFormElements() {
+  function initialiseAutosaveListeners() {
     const formElements = getFormElements()
     const form = getForm()
 
@@ -281,7 +281,7 @@
       return
     }
 
-    addListenersToFormElements()
+    initialiseAutosaveListeners()
     getForm().setAttribute('data-autosave-enabled', true)
   }
 

--- a/assets/js/save-on-exit.js
+++ b/assets/js/save-on-exit.js
@@ -17,85 +17,139 @@
     return getForm() !== null
   }
 
-  function persistForm() {
-    if (!window.reportStoreInstance) {
-      console.warn('Report store not available, falling back to form data')
-      const form = getForm()
-      const formData = new URLSearchParams(new FormData(form))
-      const reportId = formData.get('reportId')
-      const endpoint = `/psr/${reportId}/autosave`
+  function buildAutosavePayload() {
+    const form = getForm()
+    if (!form) return null
 
+    const formData = new FormData(form)
+    const reportId = formData.get('reportId')
+    if (!reportId) return null
 
-      document.dispatchEvent(new CustomEvent('autosave'))
+    const payload = new URLSearchParams()
 
-      return fetch(endpoint, {
-        method: 'POST',
-        body: formData,
-        headers: {
-          'x-csrf-token': document.getElementsByName('CSRFToken')[0].value,
-        },
+    if (window.reportStoreInstance) {
+      const storeState = window.reportStoreInstance.getState()
+      const questions = storeState.questions || {}
+
+      for (const [questionId, value] of Object.entries(questions)) {
+        if (value === undefined || value === null) continue
+
+        if (Array.isArray(value)) {
+          if (value.length === 0) {
+            payload.append(questionId, '')
+          } else {
+            value.forEach(item => payload.append(questionId, item))
+          }
+        } else {
+          payload.append(questionId, value)
+        }
+      }
+    } else {
+      const fallbackFormData = new URLSearchParams(formData)
+      fallbackFormData.forEach((value, key) => {
+        payload.append(key, value)
       })
     }
 
-    const storeState = window.reportStoreInstance.getState()
-    const questions = storeState.questions || {}
-
-    const form = getForm()
-    const formData = new URLSearchParams(new FormData(form))
-    const reportId = formData.get('reportId')
-
-    const storeFormData = new URLSearchParams()
-
-    for (const [questionId, value] of Object.entries(questions)) {
-      if (value !== undefined && value !== null) {
-        // Handle arrays (checkbox groups) specially
-        if (Array.isArray(value)) {
-          // For checkbox groups, if empty array, still send it to clear the field
-          if (value.length === 0) {
-            storeFormData.append(questionId, '')
-          } else {
-            value.forEach(v => {
-              storeFormData.append(questionId, v)
-            })
-          }
-        } else {
-          // For single values, including empty strings for unchecked checkboxes
-          storeFormData.append(questionId, value)
-        }
-      }
-    }
-
-    // Add essential form fields that might not be in the store
-    // These are typically hidden fields or system fields
     const systemFields = ['reportId', 'CSRFToken', 'pageName', 'crn', 'pnc', 'name', 'dateOfBirth', 'age', 'address']
     systemFields.forEach(fieldName => {
       const fieldValue = formData.get(fieldName)
-      if (fieldValue && !storeFormData.has(fieldName)) {
-        storeFormData.append(fieldName, fieldValue)
+      if (fieldValue && !payload.has(fieldName)) {
+        payload.append(fieldName, fieldValue)
       }
     })
 
-    if (!storeFormData.has('CSRFToken')) {
-      storeFormData.append('CSRFToken', document.getElementsByName('CSRFToken')[0].value)
+    if (!payload.has('CSRFToken')) {
+      const csrfToken = document.getElementsByName('CSRFToken')[0]?.value
+      if (csrfToken) {
+        payload.append('CSRFToken', csrfToken)
+      }
     }
 
-    const endpoint = `/psr/${reportId}/autosave`
+    return {
+      reportId,
+      endpoint: `/psr/${reportId}/autosave`,
+      payload,
+    }
+  }
+
+  function persistForm() {
+    const autosave = buildAutosavePayload()
+    if (!autosave) return Promise.resolve(null)
 
     document.dispatchEvent(new CustomEvent('autosave'))
 
-    return fetch(endpoint, {
+    return fetch(autosave.endpoint, {
       method: 'POST',
-      body: storeFormData,
+      body: autosave.payload,
       headers: {
-        'x-csrf-token': document.getElementsByName('CSRFToken')[0].value,
+        'x-csrf-token': document.getElementsByName('CSRFToken')[0]?.value,
       },
     }).then(response => {
-      // Mark changes as saved when successful
       if (response.ok && window.ReportStore) {
         window.ReportStore.markChangesSaved()
       }
       return response
     })
+  }
+
+  function sendExitAutosaveBeacon() {
+    const hasUnsavedChanges = window.ReportStore ? window.ReportStore.getHasUnsavedChanges() : false
+    if (!hasUnsavedChanges || !hasFormOnPage()) return
+
+    const autosave = buildAutosavePayload()
+    if (!autosave) return
+
+    const csrfToken = document.getElementsByName('CSRFToken')[0]?.value
+    if (!csrfToken) return
+
+    const body = new Blob([autosave.payload.toString()], {
+      type: 'application/x-www-form-urlencoded;charset=UTF-8',
+    })
+
+    // Call sendBeacon to send the autosave data to the server when the user leaves the page.
+    if (typeof navigator.sendBeacon === 'function' && navigator.sendBeacon(autosave.endpoint, body)) {
+      return
+    }
+
+    // Fallback for browsers without sendBeacon support
+    fetch(autosave.endpoint, {
+      method: 'POST',
+      body: autosave.payload,
+      keepalive: true,
+      headers: {
+        'x-csrf-token': csrfToken,
+      },
+    })
+  }
+
+  // Handle sign-out: save before logout
+  function handleSignOut(event) {
+    const hasUnsavedChanges = window.ReportStore ? window.ReportStore.getHasUnsavedChanges() : false
+    const signOutUrl = event.currentTarget?.href || '/sign-out'
+
+    if (!hasUnsavedChanges || !hasFormOnPage()) {
+      return true
+    }
+
+    event.preventDefault()
+
+    // Attempt save, but always continue logout
+    persistForm()
+      .then(async response => {
+        const text = await response.text()
+        if (response.ok) {
+          console.log('Sign-out autosave successful')
+        } else {
+          console.error(`Autosave failed (${response.status}): ${text}`)
+        }
+      })
+      .catch(e => {
+        console.error(`Sign-out autosave error: ${e.message}`)
+      })
+      .finally(() => {
+        window.location.assign(signOutUrl)
+      })
   }
 
   function addListenersToFormElements() {
@@ -193,34 +247,11 @@
     })
   }
 
-  // Handle sign-out: save before logout
-  function handleSignOut(event) {
-    const hasUnsavedChanges = window.ReportStore ? window.ReportStore.getHasUnsavedChanges() : false
-    const signOutUrl = event.currentTarget?.href || '/sign-out'
-
-    if (!hasUnsavedChanges || !hasFormOnPage()) {
-      return true
-    }
-
-    event.preventDefault()
-
-    // Attempt save, but always continue logout
-    persistForm()
-      .then(async response => {
-        const text = await response.text()
-        if (response.ok) {
-          console.log('Sign-out autosave successful')
-        } else {
-          console.error(`Autosave failed (${response.status}): ${text}`)
-        }
-      })
-      .catch(e => {
-        console.error(`Sign-out autosave error: ${e.message}`)
-      })
-      .finally(() => {
-        window.location.assign(signOutUrl)
-      })
-  }
+  // Save form data when the user leaves the page (e.g. closing tab, navigating away)
+  window.addEventListener('pagehide', event => {
+    if (event.persisted) return
+    sendExitAutosaveBeacon()
+  })
 
   window.addEventListener('load', () => {
     // Attach sign-out handler to the sign-out link

--- a/assets/js/save-on-exit.js
+++ b/assets/js/save-on-exit.js
@@ -1,9 +1,12 @@
 ;(function initialiseAutosave() {
-  const isTypeOf = elementType => element => element.type === elementType
+  // ---- UTILITIES ---- 
 
+  const isTypeOf = elementType => element => element.type === elementType
   const isRadio = isTypeOf('radio')
   const isCheckbox = isTypeOf('checkbox')
   const isSelect = element => isTypeOf('select-one')(element) || isTypeOf('select-multiple')(element)
+
+  // ---- DOM HELPERS ---- 
 
   function getForm() {
     return document.querySelector('form[data-autosave="true"]')
@@ -16,6 +19,12 @@
   function hasFormOnPage() {
     return getForm() !== null
   }
+
+  function getCsrfToken() {
+    return document.getElementsByName('CSRFToken')[0]?.value || ''
+  }
+
+  // ---- PAYLOAD BUILDER ---- 
 
   function buildAutosavePayload() {
     const form = getForm()
@@ -60,7 +69,7 @@
     })
 
     if (!payload.has('CSRFToken')) {
-      const csrfToken = document.getElementsByName('CSRFToken')[0]?.value
+      const csrfToken = getCsrfToken()
       if (csrfToken) {
         payload.append('CSRFToken', csrfToken)
       }
@@ -73,6 +82,8 @@
     }
   }
 
+  // ---- SAVE FUNCTIONS ---- 
+
   function persistForm() {
     const autosave = buildAutosavePayload()
     if (!autosave) return Promise.resolve(null)
@@ -83,7 +94,7 @@
       method: 'POST',
       body: autosave.payload,
       headers: {
-        'x-csrf-token': document.getElementsByName('CSRFToken')[0]?.value,
+        'x-csrf-token': getCsrfToken(),
       },
     }).then(response => {
       if (response.ok && window.ReportStore) {
@@ -100,7 +111,7 @@
     const autosave = buildAutosavePayload()
     if (!autosave) return
 
-    const csrfToken = document.getElementsByName('CSRFToken')[0]?.value
+    const csrfToken = getCsrfToken()
     if (!csrfToken) return
 
     const body = new Blob([autosave.payload.toString()], {
@@ -123,7 +134,16 @@
     })
   }
 
-  // Handle sign-out: save before logout
+  // ---- EVENT HANDLERS/STATE ---- 
+
+  const AUTOSAVE_DEBOUNCE_MS = 15 * 1000
+  const INTERNAL_NAV_RESET_MS = 500
+  const STORE_READY_RETRY_MS = 100
+
+  let isInternalNavigation = false
+  let isFormSubmitting = false
+  let timeoutHandle = null
+
   function handleSignOut(event) {
     const hasUnsavedChanges = window.ReportStore ? window.ReportStore.getHasUnsavedChanges() : false
     const signOutUrl = event.currentTarget?.href || '/sign-out'
@@ -152,102 +172,122 @@
       })
   }
 
-  function addListenersToFormElements() {
-    const formElements = getFormElements()
+  function onBeforeUnload(event) {
+    const hasUnsavedChanges = window.ReportStore ? window.ReportStore.getHasUnsavedChanges() : false
 
-    let timeoutHandle = null
+    if (hasUnsavedChanges && !isInternalNavigation && !isFormSubmitting) {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+  }
 
-    const hasOverLimitFields = () => {
-      const state = window.reportStoreInstance && window.reportStoreInstance.getState()
-      return Boolean(state && state.overLimitFields && state.overLimitFields.length > 0)
+  const isAnyFieldOverLimit = () => {
+    const state = window.reportStoreInstance && window.reportStoreInstance.getState()
+    return Boolean(state && state.overLimitFields && state.overLimitFields.length > 0)
+  }
+  
+  const queueAutosave = () => {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle)
     }
 
-    const handleEvent = () => {
-      if (timeoutHandle) {
-        clearTimeout(timeoutHandle)
+    timeoutHandle = setTimeout(() => {
+      if (isAnyFieldOverLimit()) {
+        return
       }
 
-      timeoutHandle = setTimeout(() => {
-        if (hasOverLimitFields()) {
-          // Skip autosave while any field exceeds the character limit; dirty flag stays set.
-          return
-        }
+      persistForm()
+        .then(async response => {
+          const text = await response.text()
+          if (!response.ok) {
+            throw new Error(`Autosave failed (${response.status}): ${text}`)
+          }
+          console.log(`Form persisted: ${text}`)
+        })
+        .catch(e => console.error(`Failed to persist form: ${e.message}`))
+    }, AUTOSAVE_DEBOUNCE_MS)
+  }
 
-        persistForm()
-          .then(async response => {
-            const text = await response.text()
-            if (!response.ok) {
-              throw new Error(`Autosave failed (${response.status}): ${text}`)
-            }
-            console.log(`Form persisted: ${text}`)
-          })
-          .catch(e => console.error(`Failed to persist form: ${e.message}`))
-      }, 15 * 1000)
-    }
+  // ---- LISTENER REGISTRATION ----
 
+  function wireAutosaveInputs(formElements) {
     if (window.reportStoreInstance && window.reportStoreInstance.subscribe) {
       window.reportStoreInstance.subscribe(() => {
-        handleEvent()
+        queueAutosave()
       })
     }
 
-    document.addEventListener('keyup', handleEvent)
+    document.addEventListener('keyup', queueAutosave)
 
     for (const element of formElements) {
       if (isRadio(element) || isCheckbox(element) || isSelect(element)) {
-        element.addEventListener('click', handleEvent)
+        element.addEventListener('click', queueAutosave)
       }
     }
+  }
 
-    // Track internal navigation to avoid showing alert for page-to-page navigation
-    let isInternalNavigation = false
-    // Track form submission to avoid showing alert when submitting the form
-    let isFormSubmitting = false
+  function wireSubmitState(form) {
+    if (!form) return
 
-    const form = getForm()
-    if (form) {
-      form.addEventListener('submit', event => {
-        // Check if the event has been prevented by other handlers (eg validation errors)
-        if (event.defaultPrevented) return
+    form.addEventListener('submit', event => {
+      // Check if the event has been prevented by other handlers (eg validation errors)
+      if (event.defaultPrevented) return
 
-        console.log('Form submission save initiated')
-        isFormSubmitting = true
-        if (timeoutHandle) {
-          clearTimeout(timeoutHandle)
-        }
-      })
-    }
+      console.log('Form submission save initiated')
 
-    document.addEventListener('click', event => {
-      const link = event.target.closest('a')
-      if (link && link.href) {
-        const linkUrl = new URL(link.href, window.location.origin)
-        const currentUrl = new URL(window.location.href)
+      isFormSubmitting = true
 
-        if (linkUrl.origin === currentUrl.origin) {
-          isInternalNavigation = true
-          // Reset after a short delay to catch the beforeunload
-          setTimeout(() => {
-            isInternalNavigation = false
-          }, 500)
-        }
-      }
-    })
-
-    // Warn user only when closing tab or navigating to external site
-    window.addEventListener('beforeunload', event => {
-      const hasUnsavedChanges = window.ReportStore ? window.ReportStore.getHasUnsavedChanges() : false
-
-      if (hasUnsavedChanges && !isInternalNavigation && !isFormSubmitting) {
-        const message = 'You have unsaved changes that will be lost. Are you sure you want to leave?'
-        event.preventDefault()
-        event.returnValue = message
-        return message
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle)
       }
     })
   }
 
-  // Save form data when the user leaves the page (e.g. closing tab, navigating away)
+  function wireInternalNavState() {
+    document.addEventListener('click', event => {
+      const link = event.target.closest('a')
+      if (!link || !link.href) return
+
+      const linkUrl = new URL(link.href, window.location.origin)
+      const currentUrl = new URL(window.location.href)
+
+      if (linkUrl.origin === currentUrl.origin) {
+        isInternalNavigation = true
+        // Reset after a short delay to catch the beforeunload
+        setTimeout(() => {
+          isInternalNavigation = false
+        }, INTERNAL_NAV_RESET_MS)
+      }
+    })
+  }
+
+  function wireLeaveWarning() {
+    window.addEventListener('beforeunload', onBeforeUnload)
+  }
+
+  function addListenersToFormElements() {
+    const formElements = getFormElements()
+    const form = getForm()
+
+    wireAutosaveInputs(formElements)
+    wireSubmitState(form)
+    wireInternalNavState()
+    wireLeaveWarning()
+  }
+
+  function startAutosaveWhenStoreReady() {
+    if (!window.reportStoreInstance) {
+      setTimeout(startAutosaveWhenStoreReady, STORE_READY_RETRY_MS)
+      return
+    }
+
+    addListenersToFormElements()
+    getForm().setAttribute('data-autosave-enabled', true)
+  }
+
+  // ---- INITIALISATION HOOKS ----
+
+  // Save form data when the user leaves the page
   window.addEventListener('pagehide', event => {
     if (event.persisted) return
     sendExitAutosaveBeacon()
@@ -262,17 +302,7 @@
 
     // Initialize autosave only if a form is present on the page
     if (hasFormOnPage()) {
-      function initializeAutosave() {
-        if (!window.reportStoreInstance) {
-          setTimeout(initializeAutosave, 100)
-          return
-        }
-
-        addListenersToFormElements()
-        getForm().setAttribute('data-autosave-enabled', true)
-      }
-
-      initializeAutosave()
+      startAutosaveWhenStoreReady()
     }
   })
 })()


### PR DESCRIPTION
**Save unsaved changes on page exit**
- Added exit-time autosave using `pagehide` event and `navigator.sendBeacon()` with a
    `fetch keepalive` fallback for browsers without sendBeacon support.

- Fires on `pagehide` (skipping bfcache restores via `event.persisted`)
    and only when there are unsaved changes and a form is present,
    preventing unnecessary requests on pages without autosave forms.

**Sign and lock page saves on side-nav clicks**
- The side-nav handler in **ckeditor5setup.js** previously skipped
    sign-and-lock, meaning changes were never explicitly saved when
    navigating away via the side nav.

- Removed the early return for /sign-your-report so all pages now
     submit with a redirectPath query param on side-nav click.

- Updated **confirm-modal.js** to only intercept button-triggered submits
     (`e.submitter` check), preventing the confirm modal from firing during
     programmatic side-nav saves.

**Refactored file**
```
// ---- UTILITIES ----
isTypeOf, isRadio, isCheckbox, isSelect

// ---- DOM HELPERS ----
getForm, getFormElements, hasFormOnPage, getCsrfToken

// ---- PAYLOAD BUILDER ----
buildAutosavePayload

// ---- SAVE FUNCTIONS ----
persistForm
sendExitAutosaveBeacon

// ---- EVENT HANDLERS/STATE ----
Constants:
  AUTOSAVE_DEBOUNCE_MS, INTERNAL_NAV_RESET_MS, STORE_READY_RETRY_MS

State:
  isInternalNavigation, isFormSubmitting, timeoutHandle

Handlers:
  handleSignOut
  onBeforeUnload
  isAnyFieldOverLimit
  queueAutosave

// ---- LISTENER REGISTRATION ----
wireAutosaveInputs(formElements)
wireSubmitState(form)
wireInternalNavState()
wireLeaveWarning()
addListenersToFormElements()
startAutosaveWhenStoreReady()

// ---- INITIALISATION HOOKS ----
pagehide listener
load listener
```