### PR TITLE
PRS-22 Character Counting Issue when Pasting

### DIFF
--- a/assets/js/character-count.js
+++ b/assets/js/character-count.js
@@ -10,17 +10,9 @@
   }
 
   function getEditableContent(field) {
-    const wrapper = field.closest('[data-editor]') || field.parentElement
-    if (wrapper) {
-      const editable = wrapper.querySelector('[contenteditable="true"], .ck-editor__editable')
-      if (editable) {
-        return editable.innerText || editable.textContent || ''
-      }
-    }
     return field.value || ''
   }
 
-  const NEWLINE_LIKE_CHARS = /\r\n|[\r\n\u2028\u2029]/g
   const INVISIBLE_NON_COUNTING_CHARS = /[\u00AD\u034F\u061C\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u2069\uFEFF]/g
 
   function normaliseForLength(value) {
@@ -32,14 +24,12 @@
       .replace(/&gt;/g, '>')
       .replace(/&#39;|&apos;/g, "'")
       .replace(/&quot;/g, '"')
-      .replace(NEWLINE_LIKE_CHARS, '') // Remove newlines, including Unicode line/paragraph separators
-      .replace(INVISIBLE_NON_COUNTING_CHARS, '') // Remove zero-width characters
+      .replace(INVISIBLE_NON_COUNTING_CHARS, '')
   }
-
 
   function getLength(field) {
     const text = getEditableContent(field)
-    return normaliseForLength(text).trim().length
+    return normaliseForLength(text).length
   }
 
   function updateCounter(field) {

--- a/assets/js/character-count.js
+++ b/assets/js/character-count.js
@@ -17,6 +17,7 @@
 
   function normaliseForLength(value) {
     return (value || '')
+      .replace(/<p>\s*(?:&nbsp;|&#160;)\s*<\/p>/gi, '') // strip empty CKEditor paragraph fillers
       .replace(/<[^>]*>/g, '')
       .replace(/&nbsp;|&#160;/gi, ' ')
       .replace(/&amp;/g, '&')

--- a/assets/js/ckeditor5setup.js
+++ b/assets/js/ckeditor5setup.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const NEWLINE_LIKE_CHARS = /\r\n|[\r\n\u2028\u2029]/g
   const INVISIBLE_NON_COUNTING_CHARS = /[\u00AD\u034F\u061C\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u2069\uFEFF]/g
 
   function normaliseForLength(value) {
@@ -11,8 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .replace(/&gt;/g, '>')
       .replace(/&#39;|&apos;/g, "'")
       .replace(/&quot;/g, '"')
-      .replace(NEWLINE_LIKE_CHARS, '') // Remove newlines, including Unicode line/paragraph separators
-      .replace(INVISIBLE_NON_COUNTING_CHARS, '') // Remove zero-width characters
+      .replace(INVISIBLE_NON_COUNTING_CHARS, '')
   }
 
   function normaliseIncomingPlainText(value) {
@@ -28,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function plainTextLength(editor) {
     const text = editor.editing.view.getDomRoot()?.innerText || ''
-    return normaliseForLength(text).trim().length
+    return normaliseForLength(text).length
   }
 
   function enforceEditorMaxLength(editor, maxLength) {
@@ -54,25 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function truncateToRemaining(rawText, remaining) {
     if (!rawText || remaining <= 0) return ''
-
     const input = normaliseIncomingPlainText(rawText)
-    let allowed = remaining
-    let out = ''
-
-    for (let i = 0; i < input.length; i += 1) {
-      const ch = input[i]
-
-      if (ch === '\n') {
-        out += ch
-        continue
-      }
-
-      if (allowed <= 0) break
-      out += ch
-      allowed -= 1
-    }
-
-    return out
+    return Array.from(input).slice(0, remaining).join('')
   }
 
   function remainingCapacity(editor, maxLength) {
@@ -118,33 +99,31 @@ document.addEventListener('DOMContentLoaded', () => {
       true
     )
 
-    // CKEditor-native clipboard pipeline
-    // Prevents paste from bypassing DOM-level beforeinput in some browsers/paths.
     const clipboard = editor.plugins.get('ClipboardPipeline')
     if (!clipboard) return
 
-    // Always flatten pasted content to plain text (formatting removed on paste)
-    clipboard.on('inputTransformation', (event, data) => {
-      // Stop default CKEditor insertion first, even when text/plain is empty.
-      event.stop()
+    clipboard.on(
+      'inputTransformation',
+      (event, data) => {
+        event.stop()
 
-      const pastedRaw = data.dataTransfer?.getData('text/plain') || ''
-      if (!pastedRaw) return
+        const pastedRaw = data.dataTransfer?.getData('text/plain') || ''
+        if (!pastedRaw) return
 
-      const remaining = remainingCapacity(editor, maxLength)
-      if (remaining <= 0) return
+        const remaining = remainingCapacity(editor, maxLength)
+        if (remaining <= 0) return
 
-      const toInsert = truncateToRemaining(pastedRaw, remaining)
-      if (!toInsert) return
+        const toInsert = truncateToRemaining(pastedRaw, remaining)
+        if (!toInsert) return
 
-      insertPlainText(editor, toInsert)
-    })
+        insertPlainText(editor, toInsert)
+      },
+      { priority: 'highest' }
+    )
 
-    // Always flatten dropped content to plain text (formatting removed on drop)
     editable.addEventListener(
       'drop',
       event => {
-        // Intercept all drops on the editable so HTML never gets inserted by default handlers.
         event.preventDefault()
         event.stopImmediatePropagation()
 
@@ -235,7 +214,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const maxLength = parseInt($el.getAttribute('data-max-length'), 10)
         enforceEditorMaxLength(editor, maxLength)
 
-        // Dispatch native event on editor data change to ensure CKEditor content is included in form submissions and autosave
         editor.model.document.on('change:data', () => {
           const html = editor.getData()
           $el.value = html

--- a/assets/js/ckeditor5setup.js
+++ b/assets/js/ckeditor5setup.js
@@ -25,7 +25,15 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function plainTextLength(editor) {
-    const text = editor.editing.view.getDomRoot()?.innerText || ''
+    const root = editor.model.document.getRoot()
+    const range = editor.model.createRangeIn(root)
+    let text = ''
+
+    for (const item of range.getItems()) {
+      if (!item.is('$textProxy')) continue
+      text += item.data
+    }
+
     return normaliseForLength(text).length
   }
 
@@ -53,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function truncateToRemaining(rawText, remaining) {
     if (!rawText || remaining <= 0) return ''
     const input = normaliseIncomingPlainText(rawText)
-    return Array.from(input).slice(0, remaining).join('')
+    return input.substring(0, remaining)
   }
 
   function remainingCapacity(editor, maxLength) {

--- a/assets/js/ckeditor5setup.js
+++ b/assets/js/ckeditor5setup.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function normaliseForLength(value) {
     return (value || '')
+      .replace(/<p>\s*(?:&nbsp;|&#160;)\s*<\/p>/gi, '') // strip empty CKEditor paragraph fillers
       .replace(/<[^>]*>/g, '')
       .replace(/&nbsp;|&#160;/gi, ' ')
       .replace(/&amp;/g, '&')
@@ -60,8 +61,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function truncateToRemaining(rawText, remaining) {
     if (!rawText || remaining <= 0) return ''
+
     const input = normaliseIncomingPlainText(rawText)
-    return input.substring(0, remaining)
+    let count = 0
+
+    for (let i = 0; i < input.length; i++) {
+      // Count all characters except newlines, which are not counted in the length limit
+      if (input[i] !== '\n') count++
+      // If we have exceeded the remaining capacity, return the substring up to this point
+      if (count > remaining) return input.substring(0, i)
+    }
+  
+    return input
   }
 
   function remainingCapacity(editor, maxLength) {


### PR DESCRIPTION
Two bugs caused the char limit to act incorrectly when pasting into rich text fields.

**Problem**

- Pasting could exceed the character limit by a variable amount.
- Pressing Enter, or simply having an empty field(textarea) inserted an character extra.
  - CKEditor does this to keep them 'alive'.

**Root causes**

- plainTextLength in **ckeditor5setup.js** read from the rendered DOM, which includes a hidden filler character CKEditor injects into empty paragraphs, causing an empty field to report  the count as 1.
- Empty paragraphs eg `<p>&nbsp;</p>` were being counted as a space character by `normaliseForLength`.
- `truncateToRemaining` in **ckeditor5setup.js** counted newline characters against the limit during paste truncation, but `normaliseForLength` in **character-count.js** did not, causing the two to sometimes disagree.

**Fix**

- `plainTextLength` now reads from the CKEditor model instead of the DOM, returning 0 for an empty field.
- `truncateToRemaining` skips newlines when counting against the limit, preserving paragraph structure in pasted content.
- `normaliseForLength` in both c**keditor5setup.js** and **character-count.js** now strips empty `<p>&nbsp;</p>` paragraphs before counting
