### PR TITLE
fix: autosave working with spellchecker flag

### DIFF
--- a/assets/js/ckeditor5setup.js
+++ b/assets/js/ckeditor5setup.js
@@ -213,31 +213,6 @@ document.addEventListener('DOMContentLoaded', () => {
     )
   }
 
-  document.querySelectorAll('.moj-side-navigation__item a').forEach(function ($el) {
-    $($el).on('click', function (event) {
-      const currentPath = window.location.pathname
-      const targetLink = event.currentTarget
-
-      if (!targetLink || !targetLink.href) {
-        return true
-      }
-
-      const formElement = document.querySelector('form[data-autosave="true"]')
-
-      if (!formElement) {
-        return true
-      }
-
-      event.preventDefault()
-      const redirectPath = targetLink.getAttribute('href')
-      const targetSegment = redirectPath.substr(redirectPath.lastIndexOf('/') + 1)
-
-      const form = $(formElement)
-      form.attr('action', currentPath + '?redirectPath=' + targetSegment)
-      form.submit()
-    })
-  })
-
   var Editor = window.ClassicEditor
   if (!Editor && typeof module !== 'undefined' && module.exports) {
     Editor = module.exports

--- a/assets/js/save-on-exit.js
+++ b/assets/js/save-on-exit.js
@@ -226,6 +226,45 @@
     }
   }
 
+  // Side-nav must submit the current form with redirectPath so page changes..
+  // ..persist even when rich-text scripts are disabled
+  function wireSideNavSubmit() {
+    document.querySelectorAll('.moj-side-navigation__item a').forEach(link => {
+      link.addEventListener('click', event => {
+        const targetLink = event.currentTarget
+
+        if (!(targetLink instanceof HTMLAnchorElement) || !targetLink.href) {
+          return
+        }
+
+        const formElement = getForm()
+        if (!formElement) {
+          return
+        }
+
+        const targetUrl = new URL(targetLink.href, window.location.origin)
+        if (targetUrl.origin !== window.location.origin) {
+          return
+        }
+
+        const targetSegment = targetUrl.pathname.split('/').filter(Boolean).pop()
+        if (!targetSegment) {
+          return
+        }
+
+        event.preventDefault()
+
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle)
+        }
+        isFormSubmitting = true
+
+        formElement.setAttribute('action', window.location.pathname + '?redirectPath=' + encodeURIComponent(targetSegment))
+        formElement.submit()
+      })
+    })
+  }
+
   function wireSubmitState(form) {
     if (!form) return
 
@@ -271,6 +310,7 @@
 
     wireAutosaveInputs(formElements)
     wireSubmitState(form)
+    wireSideNavSubmit()
     wireInternalNavState()
     wireLeaveWarning()
   }

--- a/server/views/components/text-editor/template.njk
+++ b/server/views/components/text-editor/template.njk
@@ -56,7 +56,7 @@
   {% set effectiveRows = params.rows if params.rows else "5" %}
   {% set isMultiline = effectiveRows | int > 1 %}
 
-  <textarea hidden class="govuk-textarea {%- if params.errorMessage %} govuk-textarea--error{% endif %}{%- if isMultiline %} app-apply-ckeditor5{% endif %}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"
+  <textarea hidden class="govuk-textarea {%- if params.errorMessage %} govuk-textarea--error{% endif %}{%- if isMultiline and featureRichTextEditor %} app-apply-ckeditor5{% endif %}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"
   {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
     {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
     {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}


### PR DESCRIPTION
Had to update the function for side-nav saving somewhat because:

- Save-on-exit doesn’t need jQuery and should be standalone.
- Instead of slicing with substring we parse, check same-origin, gets last path segment.
  - This avoids edge cases with absolute URLs, query strings, or malformed hrefs.
- Clears pending debounce timeout and sets isFormSubmitting = true.
  - So that it integrates with the existing unload/autosave and we dont get stray debounce saves or unload prompts during side-nav submit - might never happen but worth guarding against
- Uses encodeURIComponent(targetSegment)
  - Due to potential odd chars in path segment dont breakthe query string.
- Uses getForm() instead of re-querying manually