### PR TITLE
Replace px with pt on font sizing for PDFs, improve readability

### DIFF
--- a/assets/sass/pdf.sass
+++ b/assets/sass/pdf.sass
@@ -15,21 +15,22 @@ $moj-page-width: 1170px
   margin-left: 4px
 
 h1
-    font-size: 20px !important
+    font-size: 20pt !important
 
 h2
-    font-size: 16px !important
+    font-size: 16pt !important
     margin-bottom: 20px !important
 
 h3
-    font-size: 14px !important
+    font-size: 14pt !important
 
 .table-header
-  font-size: 14px !important
+  font-size: 14pt !important
   padding-top: 0 !important
 
 .govuk-body-s
-    font-size: 12px !important
+    font-size: 12pt !important
+    line-height: 17pt !important
 
 .pdf-secondary-text 
   color: #484949


### PR DESCRIPTION
- Changed H1 font size from 20px to 20pt.
- Changed H2 font size from 16px to 16pt.
- Changed H3 font size from 14px to 14pt.
- Changed table header font size from 14px to 14pt | **This wasnt in AC but seemed like it was maybe missed**
- Changed body text font size from 12px to 12pt.
- Added body text line height: 17pt on .govuk-body-s.
